### PR TITLE
상품 sold out 처리 및 반응형 UI 추가

### DIFF
--- a/shoppingmall/src/main/java/shoppingmall/model/product/MybatisReviewDAO.java
+++ b/shoppingmall/src/main/java/shoppingmall/model/product/MybatisReviewDAO.java
@@ -20,11 +20,11 @@ public class MybatisReviewDAO implements ReviewDAO {
 	
 	//product_id에 해당하는 전페 리뷰 객체를 불러옵니다.
 	@Override
-	public List<Review> selectByProductId(int product_id) throws ReviewNullException{
+	public List<Review> selectByProductId(int product_id) /*throws ReviewNullException*/{
 		List list = sqlSessionTemplate.selectList("Review.selectByProductId",product_id);
-		if(list.size()<1) {
-			throw new ReviewNullException("상품에 해당하는 리뷰가 존재하지 않습니다.");
-		}
+//		if(list.size()<1) {
+//			throw new ReviewNullException("상품에 해당하는 리뷰가 존재하지 않습니다.");
+//		}
 		return list;
 	}
 	

--- a/shoppingmall/src/main/webapp/WEB-INF/views/shop/inc/header.jsp
+++ b/shoppingmall/src/main/webapp/WEB-INF/views/shop/inc/header.jsp
@@ -122,6 +122,63 @@ body{
 	cursor: pointer;
 	font-weight: bold;
 }
+
+/* 반응형 UI 처리 */
+@media (max-width: 1024px) {
+	#shoppingMallName {
+		font-size: 2rem;
+	}
+
+	.search-box {
+		width: 100%;
+		margin-left: 0;
+		margin-right: 0;
+	}
+}
+
+@media (max-width: 768px) {
+	#wrapper {
+		flex-direction: column;
+		align-items: flex-start;
+	}
+
+	#logo_image {
+		width: 100px;
+	}
+
+	#shoppingMallName {
+		font-size: 1.8rem;
+	}
+
+	.search-box {
+		width: 100%;
+	}
+
+	.login, .cart, .mypage {
+		font-size: 0.9rem;
+		margin-top: 10px;
+	}
+}
+
+@media (max-width: 480px) {
+	#shoppingMallName {
+		font-size: 1rem;
+	}
+
+	.search-text {
+		font-size: 14px;
+		padding: 0 80px 0 15px;
+	}
+
+	.search-btn {
+		padding: 0 15px;
+		font-size: 14px;
+	}
+
+	.login, .cart, .mypage {
+		display: block;
+		margin: 5px 0;
+	}
 </style>
 </head>
 <body>

--- a/shoppingmall/src/main/webapp/WEB-INF/views/shop/inc/nav.jsp
+++ b/shoppingmall/src/main/webapp/WEB-INF/views/shop/inc/nav.jsp
@@ -42,6 +42,10 @@ body {
 	font-weight: bold;
 	line-height:50px;
 }
+
+.items-label a:hover {
+	color: #D70C19;
+}
 </style>
 
 <body>

--- a/shoppingmall/src/main/webapp/WEB-INF/views/shop/main.jsp
+++ b/shoppingmall/src/main/webapp/WEB-INF/views/shop/main.jsp
@@ -19,7 +19,7 @@ body {
 /* 전체 페이지 크기 설정 height: 1900px  */
 #container {
 	width: 100%;
-	height: 1900px;
+	height: auto;
 }
 
 /* 베너 관련한 스타일 */
@@ -28,10 +28,18 @@ body {
 	height: 400px;
 	background-color: green;
 }
+#banner img {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	display: block;
+}
+
 /* 인기 카테고리 범위 */
 #popular_category {
 	width: 100%;
-	height: 600px;
+	height: auto;
+	padding: 20px 0;
 }
 
 #popular_category_id {
@@ -109,6 +117,7 @@ body {
     width: 100%;
     padding: 40px 0;
     background-color: #f8f8f8;
+    margin-top: 40px;
 }
 
 .best_seller_title {
@@ -159,7 +168,91 @@ body {
     color: #555;
 }
 
+/*반응형 UI 처리*/
+@media (max-width: 768px) {
+	/* 베너 높이 줄이기 */
+	#banner {
+		height: 300px;
+	}
 
+	/* 인기 카테고리 제목 크기 */
+	#recommend_category {
+		font-size: 28px;
+	}
+
+	/* 카드 크기 및 텍스트 크기 줄이기 */
+	.popular_category_items {
+		width: 180px;
+		height: 280px;
+		padding: 15px;
+	}
+
+	.popular_category_items_label {
+		font-size: 16px;
+	}
+
+	.popular_category_items_detail {
+		font-size: 12px;
+	}
+
+	.best_seller_title {
+		font-size: 24px;
+	}
+
+	.best_seller_card {
+		width: 180px;
+	}
+
+	.product_name {
+		font-size: 14px;
+	}
+
+	.product_price {
+		font-size: 16px;
+	}
+}
+
+@media (max-width: 480px) {
+	#banner {
+		height: 250px;
+	}
+
+	/* 인기 카테고리 제목 크기 */
+	#recommend_category {
+		font-size: 22px;
+	}
+
+	/* 카드 크기 및 텍스트 크기 줄이기 */
+	.popular_category_items {
+		width: 150px;
+		height: 240px;
+		padding: 10px;
+	}
+
+	.popular_category_items_label {
+		font-size: 14px;
+	}
+
+	.popular_category_items_detail {
+		font-size: 10px;
+	}
+
+	.best_seller_title {
+		font-size: 20px;
+	}
+
+	.best_seller_card {
+		width: 150px;
+	}
+
+	.product_name {
+		font-size: 12px;
+	}
+
+	.product_price {
+		font-size: 14px;
+	}
+}
 </style>
 <body>
 	<!-- 메인 페이지 구현  -->

--- a/shoppingmall/src/main/webapp/WEB-INF/views/shop/product/detail.jsp
+++ b/shoppingmall/src/main/webapp/WEB-INF/views/shop/product/detail.jsp
@@ -216,6 +216,16 @@ if(!product.getProductImages().isEmpty()){
 	text-align: center;
 }
 
+#bt_cart_soldout {
+	padding: 6px 16px;
+	border-radius: 4px;
+	font-size: 14px;
+	font-weight: bold;
+	text-align: center;
+	background-color: #ccc;
+	color: black;
+}
+
 #bt_cart {
 	background-color: #ff9800;
 	color: white;
@@ -695,10 +705,14 @@ if(!product.getProductImages().isEmpty()){
 						<input type="text" id="quantity" value="1" readonly>
 						<button>+</button>
 					</div>
+					<%if(product.getProduct_quantity()==0){ %>
+						<div id="bt_cart_soldout" disabled>품절되었습니다.</div> 
+					<%} else { %>
 					<!-- 장바구니 담기 버튼 -->
 					<div id="bt_cart">장바구니 담기</div>
 					<!-- 구매 버튼 -->
 					<div id="bt_but">구매하기</div>
+					<% } %>
 					<!--  찜 버튼 -->
 					<div id="bt_favorite">찜</div>
 				</div>

--- a/shoppingmall/src/main/webapp/WEB-INF/views/shop/product/list.jsp
+++ b/shoppingmall/src/main/webapp/WEB-INF/views/shop/product/list.jsp
@@ -28,6 +28,8 @@
 	Map<Integer, Integer> reviewCountMap = (Map<Integer, Integer>) request.getAttribute("reviewCountMap");
 
 	String contextPath = request.getContextPath();
+	
+	String selectedThemeId = request.getParameter("theme.theme_id");
 %>
 <!DOCTYPE html>
 <html>
@@ -63,12 +65,35 @@
                     <div class="filter-section">
                         <h3>카테고리</h3>
                         <ul class="filter-list">
-                            <li><label><input type="checkbox" name="themeCheck" value="" onclick="checkOnlyOne(this, 'themeCheck', 'theme')" checked> 전체</label></li>
+                            <!-- <li><label><input type="checkbox" name="themeCheck" value="" onclick="checkOnlyOne(this, 'themeCheck', 'theme')"> 전체</label></li> -->
+                            <li>
+							    <label>
+							        <input 
+							            type="checkbox" 
+							            name="themeCheck" 
+							            value="" 
+							            onclick="checkOnlyOne(this, 'themeCheck', 'theme')" 
+							            <%= (selectedThemeId == null || selectedThemeId.equals("")) ? "checked" : "" %>>
+							        전체
+							    </label>
+							</li>
+                            
                             
                             <!-- 여기에 for문 시작-->
                             <% for(int i=0; i<themeList.size(); i++){ %>
                             <% Theme theme = themeList.get(i); %>
-                            <li><label><input type="checkbox" name="themeCheck" value="<%=theme.getTheme_id() %>"  onclick="checkOnlyOne(this, 'themeCheck', 'theme.theme_id')"><%=theme.getTheme_name() %></label></li>
+                            <!-- <li><label><input type="checkbox" name="themeCheck" value="<%=theme.getTheme_id() %>"  onclick="checkOnlyOne(this, 'themeCheck', 'theme.theme_id')"><%=theme.getTheme_name() %></label></li>  -->
+                            <li>
+						        <label>
+						            <input 
+						                type="checkbox" 
+						                name="themeCheck" 
+						                value="<%=theme.getTheme_id() %>"  
+						                onclick="checkOnlyOne(this, 'themeCheck', 'theme.theme_id')"
+						                <%= String.valueOf(theme.getTheme_id()).equals(selectedThemeId) ? "checked" : "" %>>
+						            <%=theme.getTheme_name() %>
+						        </label>
+						    </li>
                             <% } %>
                             <!-- 여기에 for문 끝-->
                             
@@ -157,6 +182,13 @@
 						<div class="product-card">
 						  <div class="product-image">
 						    <img src="<%=imageUrl%>" alt="상품이미지">
+						    
+						    <!-- sold out 처리 -->
+						    <% if(product.getProduct_quantity() == 0){ %>
+						    	<div class="sold-out-overlay">
+						    		<label>SOLD OUT</label>
+						    	</div>
+						    <% } %>
 						    <div class="product-overlay">
 						      <button class="btn btn-wishlist">♡</button>
 						      <button class="btn btn-cart">장바구니</button>

--- a/shoppingmall/src/main/webapp/static/shop/styles/product.css
+++ b/shoppingmall/src/main/webapp/static/shop/styles/product.css
@@ -168,6 +168,31 @@
     transform: scale(1.05);
 }
 
+/*상품 sold out 처리*/
+.sold-out-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.6); /* 반투명 검정 */
+  color: white;
+  font-size: 1.8rem;
+  font-weight: bold;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 100;
+  border-radius: 8px;
+}
+
+.sold-out-overlay label{
+	font-size: 35px;
+	font-style: bold;
+	color: #D70C19;
+}
+
+
 .product-overlay {
     position: absolute;
     top: 0;


### PR DESCRIPTION
### 상품의 개수가 0이면 sold out으로 UI에서 보여지도록 수정하였습니다.
- 상품 리스트에서 이미지 부분 sold out 적용
- 상품 디테일에서 장바구니, 구매하기 버튼 삭제(상품 0일때만 적용)

### 메인 페이지 반응형 ui 추가
메인 페이지에서 화면의 크기가 작아짐에 따라 배치가 깨져 반응형 ui 적용 css 추가하였습니다.

+ 참고) 메인 페이지의 베스트 셀러는 order-detail 테이블을 참조하여 작성할 예정입니다. 해당 mybatis, dao, service를 올려주시면 작업하겠습니다.