### PR TITLE
[Feat] 베스트 셀러 연동

### DIFF
--- a/shoppingmall/src/main/java/shoppingmall/model/order/MybatisOrderDetailDAO.java
+++ b/shoppingmall/src/main/java/shoppingmall/model/order/MybatisOrderDetailDAO.java
@@ -23,5 +23,10 @@ public class MybatisOrderDetailDAO implements OrderDetailDAO {
 		}
 		return orderDetailList;
 	}
+	
+	@Override
+	public List<Integer> selectTopSnapshotIds() {
+		return sqlSessionTemplate.selectList("OrderDetail.selectTopSnapshotIds");
+	}
 
 }

--- a/shoppingmall/src/main/java/shoppingmall/model/order/OrderDetailDAO.java
+++ b/shoppingmall/src/main/java/shoppingmall/model/order/OrderDetailDAO.java
@@ -7,5 +7,5 @@ import shoppingmall.domain.OrderDetail;
 public interface OrderDetailDAO {
 	
 	public List<OrderDetail> selectAll();
-	
+	public List<Integer> selectTopSnapshotIds();
 }

--- a/shoppingmall/src/main/java/shoppingmall/model/order/OrderDetailService.java
+++ b/shoppingmall/src/main/java/shoppingmall/model/order/OrderDetailService.java
@@ -3,9 +3,10 @@ package shoppingmall.model.order;
 import java.util.List;
 
 import shoppingmall.domain.OrderDetail;
+import shoppingmall.domain.Product;
 
 public interface OrderDetailService {
 	
 	public List<OrderDetail> selectAll();
-	
+	public List<Product> getTopSellingProducts();
 }

--- a/shoppingmall/src/main/java/shoppingmall/model/order/OrderDetailServiceImpl.java
+++ b/shoppingmall/src/main/java/shoppingmall/model/order/OrderDetailServiceImpl.java
@@ -1,12 +1,16 @@
 package shoppingmall.model.order;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import shoppingmall.domain.OrderDetail;
+import shoppingmall.domain.Product;
 import shoppingmall.exception.OrderDetailNotFoundException;
+import shoppingmall.model.product.ProductDAO;
+import shoppingmall.model.product.ProductSnapshotDAO;
 
 @Service
 public class OrderDetailServiceImpl implements OrderDetailService {
@@ -14,8 +18,30 @@ public class OrderDetailServiceImpl implements OrderDetailService {
 	@Autowired
 	private OrderDetailDAO orderDetailDAO;
 	
+	@Autowired
+	private ProductSnapshotDAO productSnapshotDAO;
+	
+	@Autowired
+	private ProductDAO productDAO;
+	
 	@Override
 	public List<OrderDetail> selectAll() throws OrderDetailNotFoundException {
 		return orderDetailDAO.selectAll();
+	}
+	
+	@Override
+	public List<Product> getTopSellingProducts() {
+		List<Integer> topSnapshotIds = orderDetailDAO.selectTopSnapshotIds();
+		List<String> productNames = new ArrayList<>();
+		
+		for(int id: topSnapshotIds) {
+			String name = productSnapshotDAO.selectProductNameBySnapshotId(id);
+			if(!productNames.contains(name)) {
+				productNames.add(name);
+			}
+		}
+		if(productNames.isEmpty()) return new ArrayList<>();
+		
+		return productDAO.selectTopProductByNames(productNames);
 	}
 }

--- a/shoppingmall/src/main/java/shoppingmall/model/product/MybatisProductDAO.java
+++ b/shoppingmall/src/main/java/shoppingmall/model/product/MybatisProductDAO.java
@@ -111,4 +111,9 @@ public class MybatisProductDAO implements ProductDAO{
 		return sqlSessionTemplate.selectList("Product.selectProductSearchName", product_name);
 	}
 	
+	@Override
+	public List<Product> selectTopProductByNames(List<String> names) {
+		return sqlSessionTemplate.selectList("Product.selectTopProductByNames", names);
+	}
+	
 }

--- a/shoppingmall/src/main/java/shoppingmall/model/product/MybatisProductSnapshotDAO.java
+++ b/shoppingmall/src/main/java/shoppingmall/model/product/MybatisProductSnapshotDAO.java
@@ -1,0 +1,17 @@
+package shoppingmall.model.product;
+
+import org.mybatis.spring.SqlSessionTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class MybatisProductSnapshotDAO implements ProductSnapshotDAO {
+	@Autowired
+	private SqlSessionTemplate sqlSessionTemplate;
+
+	
+	@Override
+	public String selectProductNameBySnapshotId(int id) {
+		return sqlSessionTemplate.selectOne("ProductSnapshot.selectProductNameBySnapshotId", id);
+	}
+}

--- a/shoppingmall/src/main/java/shoppingmall/model/product/ProductDAO.java
+++ b/shoppingmall/src/main/java/shoppingmall/model/product/ProductDAO.java
@@ -15,4 +15,5 @@ public interface ProductDAO {
 	public int totalCount(Theme theme); //테마 기준으로 총 상품갯수
 	public List selectByPage(int pageSize, int offset); //페이지 별로 상품 가져오기
 	public List selectByThemeWithPage(int theme_id, int pageSize, int offset); // 카테고리&페이지 기준으로 상품가져오기
+	public List<Product> selectTopProductByNames(List<String> names);	//베스트 셀러 이름으로 상품 정보 가져오기
 }

--- a/shoppingmall/src/main/java/shoppingmall/model/product/ProductSnapshotDAO.java
+++ b/shoppingmall/src/main/java/shoppingmall/model/product/ProductSnapshotDAO.java
@@ -1,0 +1,5 @@
+package shoppingmall.model.product;
+
+public interface ProductSnapshotDAO {
+	public String selectProductNameBySnapshotId(int id);
+}

--- a/shoppingmall/src/main/java/shoppingmall/mybatis/OrderDetailMapper.xml
+++ b/shoppingmall/src/main/java/shoppingmall/mybatis/OrderDetailMapper.xml
@@ -25,5 +25,13 @@
 		<include refid="columns" />
 		FROM order_detail WHERE order_summary_id = #{order_summary_id}
 	</select>
+	
+	<!-- 베스트셀러: top4 상품의 이름 가져오기 -->
+	<select id="selectTopSnapshotIds" resultType="int">
+		select product_snapshot_id from order_detail
+		group by product_snapshot_id
+		order by sum(quantity_real) desc 
+		limit 4
+	</select>
 
 </mapper>

--- a/shoppingmall/src/main/java/shoppingmall/mybatis/ProductMapper.xml
+++ b/shoppingmall/src/main/java/shoppingmall/mybatis/ProductMapper.xml
@@ -62,6 +62,14 @@
 		select * from product where product_id=#{product_id}
 	</select>
 	
+	<!-- 베스트셀러: 상품명으로 상품 정보 조회(top4) -->
+	<select id="selectTopProductByNames" parameterType="list" resultType="Product">
+		select * from product where product_name IN
+		<foreach item="product_name" collection="list" open="(" separator="," close=")">
+			#{product_name}
+		</foreach>
+	</select>
+	
 	<!-- 한 건 추가하기 -->
 	<insert id="insert" parameterType="Product">
 		insert into product(

--- a/shoppingmall/src/main/java/shoppingmall/mybatis/ProductSnapshotMapper.xml
+++ b/shoppingmall/src/main/java/shoppingmall/mybatis/ProductSnapshotMapper.xml
@@ -28,4 +28,9 @@
 	<select id="select" parameterType="int" resultMap="productMap">
 		select * from product_snapshot where product_snapshot_id=#{product_snapshot_id}
 	</select>
+	
+	<!-- 한건 이름 가져오기 -->
+	<select id="selectProductNameBySnapshotId" parameterType="int" resultType="String">
+		select product_name from product_snapshot where product_snapshot_id=#{product_snapshot_id}
+	</select>
 </mapper>

--- a/shoppingmall/src/main/java/shoppingmall/shop/controller/MainController.java
+++ b/shoppingmall/src/main/java/shoppingmall/shop/controller/MainController.java
@@ -1,16 +1,28 @@
 package shoppingmall.shop.controller;
 
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.ModelAndView;
 
+import shoppingmall.domain.Product;
+import shoppingmall.model.order.OrderDetailService;
+
 @Controller
 public class MainController {
 	
+	@Autowired
+	private OrderDetailService orderDetailService;
+	
 	@RequestMapping(value="/main", method=RequestMethod.GET)
 	public ModelAndView getMain() {
+		List<Product> topProducts = orderDetailService.getTopSellingProducts();
+		
 		ModelAndView mav = new ModelAndView("shop/main"); // mav.setViewName(""); 과 동일한 효과
+		mav.addObject("topProducts", topProducts);
 		return mav;
 	}
 }

--- a/shoppingmall/src/main/webapp/WEB-INF/views/shop/main.jsp
+++ b/shoppingmall/src/main/webapp/WEB-INF/views/shop/main.jsp
@@ -1,6 +1,9 @@
+<%@page import="shoppingmall.util.PriceFormat"%>
+<%@page import="shoppingmall.domain.Product"%>
 <%@page import="com.fasterxml.jackson.annotation.JsonInclude.Include"%>
 <%@ page language="java" contentType="text/html; charset=UTF-8"
 	pageEncoding="UTF-8"%>
+<% String contextPath = request.getContextPath(); %>
 <!DOCTYPE html>
 <html>
 <head>
@@ -318,34 +321,21 @@ body {
 		<div class="best_seller" id="best_seller">
 			<h2 class="best_seller_title">베스트 셀러</h2>
 			<div class="best_seller_card_wrap">
-				<!-- 카드 1 -->
-				<div class="best_seller_card">
-					<img src="../img/main/best1.png" alt="식스틴">
-					<div class="product_name">식스틴</div>
-					<div class="product_price">45,000원</div>
-					<div class="product_rating">★★★★★ (271)</div>
+				<% List<Product> topProducts = (List<Product>)request.getAttribute("topProducts"); 
+					for(Product p : topProducts){
+						
+					//상품 이미지 경로 가져오기
+					 String imageUrl = "";
+					 if(!p.getProductImages().isEmpty()){
+						imageUrl = contextPath+"/data/p_"+p.getProduct_id()+"/"+p.getProductImages().get(0).getFileName();
+					 }
+				%>
+				<div class="best_seller_card" onclick="location.href='/shop/product/detail?product_id=<%=p.getProduct_id()%>';">
+					<img src="<%=imageUrl %>" alt="상품이미지">
+					<div class="product_name"><%=p.getProduct_name() %></div>
+					<div class="product_price"><%=PriceFormat.productPriceFormat(p.getSalePrice())%>원</div>
 				</div>
-				<!-- 카드 2 -->
-				<div class="best_seller_card">
-					<img src="../img/main/best2.png" alt="코드톡">
-					<div class="product_name">코드톡</div>
-					<div class="product_price">24,000원</div>
-					<div class="product_rating">★★★★★ (204)</div>
-				</div>
-				<!-- 카드 3 -->
-				<div class="best_seller_card">
-					<img src="../img/main/best3.png" alt="라이징5">
-					<div class="product_name">라이징5</div>
-					<div class="product_price">37,900원</div>
-					<div class="product_rating">★★★★☆ (79)</div>
-				</div>
-				<!-- 카드 4 -->
-				<div class="best_seller_card">
-					<img src="../img/main/best4.png" alt="파일업 러시">
-					<div class="product_name">파일업 러시</div>
-					<div class="product_price">52,000원</div>
-					<div class="product_rating">★★★☆☆ (93)</div>
-				</div>
+				<% } %>
 			</div>
 		</div>
 


### PR DESCRIPTION
### 메인 페이지의 베스트 셀러 연동
메인 페이지의 베스트 셀러 상품을 연동하였습니다.
- 주문 상세 테이블을 조회하여 가장 많은 구매 수량의 top 4 상품의 이름을 얻어옵니다.
- 해당 이름으로 상품 테이블의 정보를 가져와 메인 페이지에 뿌려주고, 상품을 선택 시 디테일 페이지로 product_id를 넘기도록 구현하였습니다.

+ 참고) 해당 로직은 상품의 이름은 변경되지 않는다는 가정이 성립되어야 합니다. 보다 좋은 로직이 있으시면 말씀해주세요.
언제든지 고칠 준비 되어 있습니다. 감사합니다.