### PR TITLE
feat: 회원정보상세페이지, 주문관리 페이지,  상품 삭제 구현

### DIFF
--- a/shoppingmall/src/main/java/shoppingmall/admin/controller/CsController.java
+++ b/shoppingmall/src/main/java/shoppingmall/admin/controller/CsController.java
@@ -12,6 +12,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.servlet.ModelAndView;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import lombok.extern.slf4j.Slf4j;
 import shoppingmall.domain.Qna;
 import shoppingmall.domain.ResponseMessage;
@@ -27,19 +30,20 @@ public class CsController {
 	private QnaService qnaService;
 	@Autowired
 	private Paging paging;
+	@Autowired
+	private ObjectMapper objectMapper;
 	
 	@GetMapping("/cs/qna/listpage")
 	public ModelAndView getQnaPageList(
-			@RequestParam(name = "pagenum", required = false) String pagenum
+			@RequestParam(name = "pagenum", required = false, defaultValue = "1") String pagenum
 	) {
-		int currentPage = 1;
-		if(pagenum != null) {
-			currentPage = Integer.parseInt(pagenum);
-		}
-		paging.init(currentPage, currentPage);
-		List<Qna> qnas = qnaService.selectOrderBy();
+		int totalRecored = qnaService.totalRecord();
+		int currentPage = Integer.parseInt(pagenum);
+		paging.init(totalRecored, currentPage);
+		List<Qna> qnas = qnaService.selectAllOrderBy(paging.getPageSize(), paging.getCurPos());
 		ModelAndView modelAndView = new ModelAndView("/management/cs/qna/list");
 		modelAndView.addObject("qnas", qnas);	
+		modelAndView.addObject("paging", paging);
 		return modelAndView;
 	}
 	

--- a/shoppingmall/src/main/java/shoppingmall/admin/controller/CsController.java
+++ b/shoppingmall/src/main/java/shoppingmall/admin/controller/CsController.java
@@ -43,6 +43,22 @@ public class CsController {
 		return modelAndView;
 	}
 	
+	@GetMapping("/cs/qna/list")
+	@ResponseBody
+	public ResponseEntity<String> getQnaListByMember(
+			@RequestParam(name = "member_id", required = true) String memberId) {
+		List<Qna> qnas = qnaService.selectByMemberId(Integer.parseInt(memberId));
+		log.debug("가져온 문의 {}", qnas);
+		try {
+			String json = objectMapper.writeValueAsString(qnas);
+			log.debug("변경한 문자 {}", json);
+			return ResponseEntity.ok(json);
+		} catch (JsonProcessingException e) {
+			e.printStackTrace();
+			return null;
+		}
+	} 
+	
 	@GetMapping("/cs/qna/detail")
 	public ModelAndView getQnaDetailPage (
 			@RequestParam(name = "qna_id", required = true) String qnaId

--- a/shoppingmall/src/main/java/shoppingmall/admin/controller/MemberController.java
+++ b/shoppingmall/src/main/java/shoppingmall/admin/controller/MemberController.java
@@ -11,6 +11,7 @@ import org.springframework.web.servlet.ModelAndView;
 import lombok.extern.slf4j.Slf4j;
 import shoppingmall.domain.Member;
 import shoppingmall.model.member.MemberService;
+import shoppingmall.util.Paging;
 
 @Slf4j
 @Controller
@@ -18,12 +19,20 @@ public class MemberController {
 
 	@Autowired
 	private MemberService memberService;
+	@Autowired
+	private Paging paging;
 	
-	@GetMapping("/member/list")
-	public ModelAndView getMemberListPage() {
-		List<Member> members = memberService.selectAll();
+	@GetMapping("/member/listpage")
+	public ModelAndView getMemberListPage(
+			@RequestParam(name = "pagenum", required = false, defaultValue = "1") String pagenum
+			) {
+		int totalRecord = memberService.totalRecord();
+		int currentPage = Integer.parseInt(pagenum);
+		paging.init(totalRecord, currentPage);
+		List<Member> members = memberService.selectByPage(paging.getPageSize(), paging.getCurPos());
 		ModelAndView modelAndView = new ModelAndView("/management/member/list");
 		modelAndView.addObject("members", members);
+		modelAndView.addObject("paging", paging);
 		return modelAndView;
 	}
 	

--- a/shoppingmall/src/main/java/shoppingmall/admin/controller/OrderController.java
+++ b/shoppingmall/src/main/java/shoppingmall/admin/controller/OrderController.java
@@ -10,6 +10,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.servlet.ModelAndView;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import lombok.extern.slf4j.Slf4j;
 import shoppingmall.domain.Member;
 import shoppingmall.domain.OrderSummary;
@@ -25,12 +28,14 @@ public class OrderController {
 	private OrderSummaryService orderSummaryService;
 	@Autowired
 	private Paging paging;
+	@Autowired
+	private ObjectMapper objectMapper;
 	
 	
 	@GetMapping("/order/history/listpage")
 	public ModelAndView getOrderListPage(
 			@RequestParam(name = "pagenum", required = false, defaultValue = "1") String pagenum,
-			@RequestParam(name = "status_id", required = false) String statusId) {
+			@RequestParam(name = "status_id", required = false, defaultValue = "1") String statusId) {
 		Status status = new Status();
 		if (statusId != null) {
 			status.setStatus_id(Integer.parseInt(statusId));
@@ -50,7 +55,7 @@ public class OrderController {
 	@GetMapping("/order/inquiry/listpage")
 	public ModelAndView getInquiryListPage(
 			@RequestParam(name = "pagenum", required = false, defaultValue = "1") String pagenum,
-			@RequestParam(name = "status_id", required = false) String statusId) {
+			@RequestParam(name = "status_id", required = false, defaultValue = "7") String statusId) {
 		Status status = new Status();
 		if (statusId != null) {
 			status.setStatus_id(Integer.parseInt(statusId));
@@ -70,7 +75,7 @@ public class OrderController {
 	@GetMapping("/order/return/listpage")
 	public ModelAndView getReturnListPage(
 			@RequestParam(name = "pagenum", required = false, defaultValue = "1") String pagenum,
-			@RequestParam(name = "status_id", required = false) String statusId) {
+			@RequestParam(name = "status_id", required = false, defaultValue = "6") String statusId) {
 		Status status = new Status();
 		if (statusId != null) {
 			status.setStatus_id(Integer.parseInt(statusId));
@@ -84,6 +89,15 @@ public class OrderController {
 		ModelAndView modelAndView = new ModelAndView("/management/order/return");
 		modelAndView.addObject("orderSummaries", orderSummaries);
 		modelAndView.addObject("paging", paging);
+		return modelAndView;
+	}
+	
+	@GetMapping("/order/{type:history|inquiry|return}/detail")
+	public ModelAndView getOrderDetailPage(
+			@RequestParam(name = "order_summery_id", required = true) String orderSummeryId) {
+		OrderSummary orderSummary = orderSummaryService.select(Integer.parseInt(orderSummeryId));
+		ModelAndView modelAndView = new ModelAndView("/management/order/detail");
+		modelAndView.addObject("orderSummary", orderSummary);
 		return modelAndView;
 	}
 	

--- a/shoppingmall/src/main/java/shoppingmall/admin/controller/OrderController.java
+++ b/shoppingmall/src/main/java/shoppingmall/admin/controller/OrderController.java
@@ -90,17 +90,18 @@ public class OrderController {
 	
 	@GetMapping("/order/history/list")
 	@ResponseBody
-	public ResponseEntity<String> getOrderList(
-			@RequestParam(name = "member_id", required = false) String memberId 
+	public ResponseEntity<String> getOrderListByMemberId(
+			@RequestParam(name = "member_id", required = true) String memberId 
 	){
-		if(memberId != null) {
-			Member member = new Member();
-			member.setMember_id(Integer.parseInt(memberId));
-			//TODO("멤버 기준으로 주문 내역 불러오기")			
-		} else {
-			//TODO("전체 주문내역 불러오기")
+		Member member = new Member();
+		member.setMember_id(Integer.parseInt(memberId));
+		List<OrderSummary> orderSummaries = orderSummaryService.selectByMember(member);
+		try {
+			String json = objectMapper.writeValueAsString(orderSummaries);
+			return ResponseEntity.ok(json);
+		} catch (JsonProcessingException e) {
+			return null;
 		}
-		return null;
 	}
 	
 	@GetMapping("/order/detail")

--- a/shoppingmall/src/main/java/shoppingmall/admin/controller/ProductController.java
+++ b/shoppingmall/src/main/java/shoppingmall/admin/controller/ProductController.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.ModelAndView;
 import javax.servlet.http.HttpServletRequest;
@@ -20,6 +21,7 @@ import shoppingmall.domain.AgeRange;
 import shoppingmall.domain.Difficulty;
 import shoppingmall.domain.PlayerRange;
 import shoppingmall.domain.Product;
+import shoppingmall.domain.ResponseMessage;
 import shoppingmall.domain.Theme;
 import shoppingmall.domain.request.ProductDto;
 import shoppingmall.model.product.AgeRangeService;
@@ -190,5 +192,24 @@ public class ProductController {
 		modelAndView.addObject("ageRanges", ageRanges);
 		modelAndView.addObject("playerRanges", playerRanges);
 		return modelAndView;
+	}
+	
+	@PostMapping("/product/remove")
+	@ResponseBody
+	public ResponseEntity<ResponseMessage<String>> removeProduct(
+			@RequestParam(name = "product_id", required = true) String productId, HttpServletRequest request) {
+		ResponseMessage<String> responseMessage = new ResponseMessage<>();
+		try {
+			Product product = new Product();
+			product.setProduct_id(Integer.parseInt(productId));
+			String saveImagePath = request.getServletContext().getRealPath("/data");
+			productService.remove(product, saveImagePath);
+			responseMessage.setResult(true);
+			responseMessage.setData("상품이 삭제되었습니다.");
+		} catch (Exception e) {
+			responseMessage.setResult(false);
+			responseMessage.setErrorMessage(e.getMessage());
+		}
+		return ResponseEntity.ok(responseMessage);
 	}
 }

--- a/shoppingmall/src/main/java/shoppingmall/domain/Delivery.java
+++ b/shoppingmall/src/main/java/shoppingmall/domain/Delivery.java
@@ -1,5 +1,6 @@
 package shoppingmall.domain;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import lombok.Data;
 
 @Data
@@ -9,5 +10,6 @@ public class Delivery {
 	private String address_alias;
 	private String receiver_name;
 	private String receiver_phone;
+	@JsonBackReference("member-deliveries")
 	private Member member;
 }

--- a/shoppingmall/src/main/java/shoppingmall/domain/Member.java
+++ b/shoppingmall/src/main/java/shoppingmall/domain/Member.java
@@ -2,6 +2,7 @@ package shoppingmall.domain;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.Data;
 
 @Data
@@ -18,7 +19,10 @@ public class Member {
 	private int point_remained;				//회원의 잔여포인트
 	private String default_address; 		//기본배송지
 	
+	@JsonManagedReference("member-reviews")
 	List<Review> reviewList;				//자식인 review를 collection 객체인 List로 보유한다.
+	@JsonManagedReference("member-qnas")
 	List<Qna> qnaList;						//자식인 qna를 collection 객체인 List로 보유한다.
+	@JsonManagedReference("member-deliveries")
 	List<Delivery> deliveryList;			//자식인 delivery를 collection 객체인 List로 보유한다.
 }

--- a/shoppingmall/src/main/java/shoppingmall/domain/OrderDetail.java
+++ b/shoppingmall/src/main/java/shoppingmall/domain/OrderDetail.java
@@ -1,11 +1,13 @@
 package shoppingmall.domain;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import lombok.Data;
 
 @Data
 public class OrderDetail {
 	private int order_detail_id;
 	private int quantity_real;
+	@JsonBackReference("order-details")
 	private OrderSummary orderSummary;
 	private ProductSnapshot productSnapshot;
 }

--- a/shoppingmall/src/main/java/shoppingmall/domain/OrderSummary.java
+++ b/shoppingmall/src/main/java/shoppingmall/domain/OrderSummary.java
@@ -2,6 +2,7 @@ package shoppingmall.domain;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.Data;
 
 @Data
@@ -17,5 +18,6 @@ public class OrderSummary {
 	private Status status;
 	private Delivery delivery;
 	
+	@JsonManagedReference("order-details")
 	private List<OrderDetail> orderDetailList; //자식을 컬렉션 객체인 리스트로 보유한다.
 }

--- a/shoppingmall/src/main/java/shoppingmall/domain/Product.java
+++ b/shoppingmall/src/main/java/shoppingmall/domain/Product.java
@@ -4,6 +4,7 @@ import java.beans.Transient;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.Data;
 import lombok.ToString;
 
@@ -19,8 +20,10 @@ public class Product {
 	private String regdate;
 	private int play_time;
 	@ToString.Exclude
+	@JsonManagedReference("product-images")
 	private List<ProductImage> productImages = new ArrayList<>();
 	@ToString.Exclude
+	@JsonManagedReference("product-reviews")
 	private List<Review> reviews;
 	
 	private Theme theme;

--- a/shoppingmall/src/main/java/shoppingmall/domain/ProductImage.java
+++ b/shoppingmall/src/main/java/shoppingmall/domain/ProductImage.java
@@ -1,5 +1,6 @@
 package shoppingmall.domain;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import lombok.Data;
 import lombok.ToString;
 
@@ -8,6 +9,7 @@ public class ProductImage {
 	private int productImageId;
 	private String fileName;
 	@ToString.Exclude
+	@JsonBackReference("product-images")
 	private Product product;
 }
 

--- a/shoppingmall/src/main/java/shoppingmall/domain/Review.java
+++ b/shoppingmall/src/main/java/shoppingmall/domain/Review.java
@@ -1,5 +1,6 @@
 package shoppingmall.domain;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import lombok.Data;
 import lombok.ToString;
 
@@ -10,6 +11,8 @@ public class Review {
 	private String reviewed_at;
 	private int rating;
 	@ToString.Exclude
+	@JsonBackReference("product-reviews")
 	private Product product;
+	@JsonBackReference("member-reviews")
 	private Member member;
 }

--- a/shoppingmall/src/main/java/shoppingmall/exception/ProductDeleteException.java
+++ b/shoppingmall/src/main/java/shoppingmall/exception/ProductDeleteException.java
@@ -1,0 +1,16 @@
+package shoppingmall.exception;
+
+public class ProductDeleteException extends RuntimeException{
+	public ProductDeleteException(String msg) {
+		super(msg);
+	}
+	
+	public ProductDeleteException(Throwable e) {
+		super(e);
+	}
+	
+	public ProductDeleteException(String msg, Throwable e) {
+		super(msg, e);
+	}
+	
+}

--- a/shoppingmall/src/main/java/shoppingmall/model/member/MemberDAO.java
+++ b/shoppingmall/src/main/java/shoppingmall/model/member/MemberDAO.java
@@ -3,6 +3,7 @@ package shoppingmall.model.member;
 
 import java.sql.Timestamp;
 import java.util.List;
+import java.util.Map;
 
 import shoppingmall.domain.Member;
 
@@ -20,4 +21,6 @@ public interface MemberDAO {
 	public Member login(Member member);						//홈페이지 로그인
 	public Member snsLogin(Member member);					//SNS로그인
 	public Member findIdAndPwd(String name, String phone);	//아이디, 비밀번호 찾기
+	public int totalRecord();
+	public List<Member> selectByPage(Map<String, Object> map);
 }

--- a/shoppingmall/src/main/java/shoppingmall/model/member/MemberService.java
+++ b/shoppingmall/src/main/java/shoppingmall/model/member/MemberService.java
@@ -7,6 +7,7 @@ import shoppingmall.domain.Member;
 
 public interface MemberService {
 	public List<Member> selectAll();
+	public List<Member> selectByPage(int pageSize, int offset);	
 	public Member select(int memberId);
 	public Member selectWithDelivery(int memberId);
 	public Member selectById(String id);
@@ -15,4 +16,5 @@ public interface MemberService {
 	public void edit(Member member, String password, String phone);
 	public void remove(int member_id);
 	public Member login(Member member);
+	public int totalRecord();
 }

--- a/shoppingmall/src/main/java/shoppingmall/model/member/MemberServiceImpl.java
+++ b/shoppingmall/src/main/java/shoppingmall/model/member/MemberServiceImpl.java
@@ -1,7 +1,9 @@
 package shoppingmall.model.member;
 
 import java.sql.Timestamp;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -43,6 +45,14 @@ public class MemberServiceImpl implements MemberService {
 	
 	public List<Member> selectAll() {
 		return memberDAO.selectAll();
+	}
+	
+	@Override
+	public List<Member> selectByPage(int pageSize, int offset) {
+		Map<String, Object> map = new HashMap<>();
+		map.put("page_size", pageSize);
+		map.put("offset", offset);
+		return memberDAO.selectByPage(map);
 	}
 	
 	@Override
@@ -166,6 +176,11 @@ public class MemberServiceImpl implements MemberService {
 			throw new MemberRemoveException("회원 삭제 실패");
 		} 
 		
+	}
+	
+	@Override
+	public int totalRecord() {
+		return memberDAO.totalRecord();
 	}
 	
 }

--- a/shoppingmall/src/main/java/shoppingmall/model/member/MybatisMemberDAO.java
+++ b/shoppingmall/src/main/java/shoppingmall/model/member/MybatisMemberDAO.java
@@ -44,6 +44,11 @@ public class MybatisMemberDAO implements MemberDAO {
 	}
 	
 	@Override
+	public List<Member> selectByPage(Map<String, Object> map) {
+		return sqlSessionTemplate.selectList("Member.selectByPage", map);
+	}
+	
+	@Override
 	public Member select(int member_id) {
 		return sqlSessionTemplate.selectOne("Member.select", member_id);
 	}
@@ -125,4 +130,8 @@ public class MybatisMemberDAO implements MemberDAO {
 		}
 	}
 	
+	@Override
+	public int totalRecord() {
+		return sqlSessionTemplate.selectOne("Member.totalRecord");
+	}
 }

--- a/shoppingmall/src/main/java/shoppingmall/model/order/MybatisOrderSummaryDAO.java
+++ b/shoppingmall/src/main/java/shoppingmall/model/order/MybatisOrderSummaryDAO.java
@@ -24,6 +24,16 @@ public class MybatisOrderSummaryDAO implements OrderSummaryDAO{
 	private SqlSessionTemplate sqlSessionTemplate;
 	
 	@Override
+	public OrderSummary select(int summery_id) throws OrderSummaryNotFoundException {
+		try {
+			OrderSummary orderSummary = sqlSessionTemplate.selectOne("OrderSummary.select", summery_id);
+			return orderSummary;
+		} catch (Exception e) {
+			throw new OrderSummaryNotFoundException(e);
+		}
+	}
+	
+	@Override
 	public List<OrderSummary> selectByMember(Member member) {
 		List<OrderSummary> orderSummaryList = sqlSessionTemplate.selectList("OrderSummary.selectByMember", member);
 		if(orderSummaryList == null) {

--- a/shoppingmall/src/main/java/shoppingmall/model/order/OrderSummaryDAO.java
+++ b/shoppingmall/src/main/java/shoppingmall/model/order/OrderSummaryDAO.java
@@ -4,7 +4,6 @@ import java.sql.Timestamp;
 import java.util.List;
 import java.util.Map;
 
-import shoppingmall.domain.Delivery;
 import shoppingmall.domain.Member;
 import shoppingmall.domain.OrderSummary;
 import shoppingmall.domain.Status;
@@ -26,5 +25,6 @@ public interface OrderSummaryDAO {
 	public void Insert(OrderSummary ordersummary);
 	
 	public int totalRecord(Status status);
+	public OrderSummary select(int summery_id);
 	
 }

--- a/shoppingmall/src/main/java/shoppingmall/model/order/OrderSummaryService.java
+++ b/shoppingmall/src/main/java/shoppingmall/model/order/OrderSummaryService.java
@@ -2,13 +2,12 @@ package shoppingmall.model.order;
 
 import java.sql.Timestamp;
 import java.util.List;
-import java.util.Map;
-
 import shoppingmall.domain.Member;
 import shoppingmall.domain.OrderSummary;
 import shoppingmall.domain.Status;
 
 public interface OrderSummaryService {
+	public OrderSummary select(int summeryId);
 	public List<OrderSummary> selectByMember(Member member);
 	public List<OrderSummary> selectByPageAndMember(String page, Member member, Timestamp startDate, Timestamp endDate);
 	public List<OrderSummary> selectByOrder(int pageSize, int currentPage);

--- a/shoppingmall/src/main/java/shoppingmall/model/order/OrderSummaryServiceImpl.java
+++ b/shoppingmall/src/main/java/shoppingmall/model/order/OrderSummaryServiceImpl.java
@@ -26,6 +26,11 @@ public class OrderSummaryServiceImpl implements OrderSummaryService {
 	private StatusDAO statusDAO;
 	
 	@Override
+	public OrderSummary select(int summeryId) throws OrderSummaryNotFoundException {
+		return orderSummaryDAO.select(summeryId);
+	}
+	
+	@Override
 	public List<OrderSummary> selectByMember(Member member) {
 		return orderSummaryDAO.selectByMember(member);
 	}

--- a/shoppingmall/src/main/java/shoppingmall/model/product/MybatisProductDAO.java
+++ b/shoppingmall/src/main/java/shoppingmall/model/product/MybatisProductDAO.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Repository;
 
 import shoppingmall.domain.Product;
 import shoppingmall.domain.Theme;
+import shoppingmall.exception.ProductDeleteException;
 import shoppingmall.exception.ProductException;
 import shoppingmall.exception.ProductGetTotalCountException;
 import shoppingmall.exception.ProductInsertException;
@@ -116,4 +117,16 @@ public class MybatisProductDAO implements ProductDAO{
 		return sqlSessionTemplate.selectList("Product.selectTopProductByNames", names);
 	}
 	
+	@Override
+	public void delete(Product product) throws ProductDeleteException {
+		try {
+			int result = sqlSessionTemplate.delete("Product.delete", product);
+			if(result < 1) {
+				throw new ProductDeleteException("상품 삭제 실패");
+			}
+		} catch (Exception e) {
+			throw new ProductDeleteException(e);
+		}
+		
+	}
 }

--- a/shoppingmall/src/main/java/shoppingmall/model/product/MybatisProductImageDAO.java
+++ b/shoppingmall/src/main/java/shoppingmall/model/product/MybatisProductImageDAO.java
@@ -30,6 +30,9 @@ public class MybatisProductImageDAO implements ProductImageDAO {
 	public void deletByProductId(int product_id) throws ProductImageDeleteException {
 		try {
 			int result = sqlSessionTemplate.delete("ProductImage.deleteByProductId", product_id);
+			if(result < 1) {
+				throw new ProductImageDeleteException("이미지 삭제 실패");
+			}
 		} catch (Exception e) {
 			throw new ProductImageDeleteException(e);
 		}

--- a/shoppingmall/src/main/java/shoppingmall/model/product/MybatisQnaDAO.java
+++ b/shoppingmall/src/main/java/shoppingmall/model/product/MybatisQnaDAO.java
@@ -38,6 +38,15 @@ public class MybatisQnaDAO implements QnaDAO{
 			throw new QnASelectException(e);
 		}
 	}
+	
+	@Override
+	public List<Qna> selectByMemberId(int member_id) throws QnASelectException {
+		try {
+			return sqlSessionTemplate.selectList("Qna.selectQnaByMemberId", member_id);
+		} catch (Exception e) {
+			throw new QnASelectException(e);
+		}
+	}
 
 	@Override
 	public Qna select(int qna_id) throws QnaNullException{
@@ -93,6 +102,11 @@ public class MybatisQnaDAO implements QnaDAO{
 	public List<Qna> selectByProductId(int product_id) {
 		List<Qna> result = sqlSessionTemplate.selectList("Qna.selectByProductId",product_id);
 		return result;
+	}
+	
+	@Override
+	public int totalRecord() {
+		return sqlSessionTemplate.selectOne("Qna.totalRecord");
 	}
 	
 }

--- a/shoppingmall/src/main/java/shoppingmall/model/product/ProductDAO.java
+++ b/shoppingmall/src/main/java/shoppingmall/model/product/ProductDAO.java
@@ -16,4 +16,5 @@ public interface ProductDAO {
 	public List selectByPage(int pageSize, int offset); //페이지 별로 상품 가져오기
 	public List selectByThemeWithPage(int theme_id, int pageSize, int offset); // 카테고리&페이지 기준으로 상품가져오기
 	public List<Product> selectTopProductByNames(List<String> names);	//베스트 셀러 이름으로 상품 정보 가져오기
+	public void delete(Product product);
 }

--- a/shoppingmall/src/main/java/shoppingmall/model/product/ProductService.java
+++ b/shoppingmall/src/main/java/shoppingmall/model/product/ProductService.java
@@ -17,4 +17,5 @@ public interface ProductService {
 	public int totalCount(Theme theme);
 	public List selectByPage(int pageSize, int currentPage);
 	public List selectByThemeWithPage(int themeId, int pageSize, int currentPage);
+	public void remove(Product product, String savePath);
 }

--- a/shoppingmall/src/main/java/shoppingmall/model/product/ProductServiceImp.java
+++ b/shoppingmall/src/main/java/shoppingmall/model/product/ProductServiceImp.java
@@ -13,7 +13,9 @@ import shoppingmall.domain.ProductImage;
 import shoppingmall.domain.Theme;
 import shoppingmall.domain.request.ProductDto;
 import shoppingmall.exception.FileUploadException;
+import shoppingmall.exception.ProductDeleteException;
 import shoppingmall.exception.ProductException;
+import shoppingmall.exception.ProductImageDeleteException;
 import shoppingmall.exception.ProductImageInsertException;
 import shoppingmall.exception.ProductInsertException;
 import shoppingmall.util.FileManager;
@@ -105,5 +107,13 @@ public class ProductServiceImp implements ProductService{
 	public List selectByThemeWithPage(int themeId, int pageSize, int currentPage) {
 		int offset = (currentPage - 1) * 10;
 		return productDAO.selectByThemeWithPage(themeId, pageSize, offset);
+	}
+	
+	@Override
+	@Transactional
+	public void remove(Product product, String savePath) throws ProductDeleteException, ProductImageDeleteException {
+		productImageDAO.deletByProductId(product.getProduct_id());
+		fileManager.remove(product, savePath);
+		productDAO.delete(product);
 	}
 }

--- a/shoppingmall/src/main/java/shoppingmall/model/product/QnaDAO.java
+++ b/shoppingmall/src/main/java/shoppingmall/model/product/QnaDAO.java
@@ -13,7 +13,9 @@ public interface QnaDAO {
 	public void delete(int qna_id);
 	public void updateFromAdmin(Qna qna);
 	public int qnaCount(int product_id);
-	
+
 	//물건 한 건 당 QNA 얻어오기
 	public List<Qna> selectByProductId(int product_id);
+	public int totalRecord();
+	public List<Qna> selectByMemberId(int member_id);
 }

--- a/shoppingmall/src/main/java/shoppingmall/model/product/QnaService.java
+++ b/shoppingmall/src/main/java/shoppingmall/model/product/QnaService.java
@@ -6,15 +6,17 @@ import shoppingmall.domain.Qna;
 
 public interface QnaService {
 	public List<Qna> selectAll();
-	public List<Qna> selectOrderBy();
+	public List<Qna> selectAllOrderBy(int pageSize, int offset);
+	public List<Qna> selectByMemberId(int memberId);
 	public Qna select(int qna_id);
 	public void insert(Qna qna);
 	public void update(Qna qna);
 	public void updateFromAdmin(Qna qna);
 	public void delete(int qna_id);
 	public int count(int product_id);
-	
-	
+
+
 	//물건 한 건에 해당하는 QNA 가지고 오
 	public List<Qna> selectByProductId(int product_id);
+	public int totalRecord();
 	}

--- a/shoppingmall/src/main/java/shoppingmall/model/product/QnaServiceImpl.java
+++ b/shoppingmall/src/main/java/shoppingmall/model/product/QnaServiceImpl.java
@@ -1,6 +1,8 @@
 package shoppingmall.model.product;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -22,8 +24,16 @@ public class QnaServiceImpl implements QnaService{
 	}
 	
 	@Override
-	public List<Qna> selectOrderBy() throws QnASelectException {
+	public List<Qna> selectAllOrderBy(int pageSize, int offset) throws QnASelectException {
+		Map<String, Object> map = new HashMap<>();
+		map.put("page_size", pageSize);
+		map.put("offset", offset);
 		return qnaDAO.selectAllOrderBy();
+	}
+	
+	@Override
+	public List<Qna> selectByMemberId(int memberId) {
+		return qnaDAO.selectByMemberId(memberId);
 	}
 
 	@Override
@@ -60,6 +70,11 @@ public class QnaServiceImpl implements QnaService{
 	@Override
 	public List<Qna> selectByProductId(int product_id) {
 		return qnaDAO.selectByProductId(product_id);
+	}
+	
+	@Override
+	public int totalRecord() {
+		return qnaDAO.totalRecord();
 	}
 	
 }

--- a/shoppingmall/src/main/java/shoppingmall/mybatis/MemberMapper.xml
+++ b/shoppingmall/src/main/java/shoppingmall/mybatis/MemberMapper.xml
@@ -86,6 +86,11 @@
 		WHERE member_name = #{member_name} AND phone = #{phone}
 	</select>
 	
+	<!--  페이징으로 조회 -->
+	<select id="selectByPage" parameterType="map" resultType="Member">
+		SELECT <include refid="columns"/> FROM member ORDER BY joined_at DESC LIMIT #{page_size} OFFSET #{offset}
+	</select>
+	
 	<!-- 홈페이지 로그인 회원 조회 -->
 	<select id="login" parameterType="Member" resultType="Member">
 		SELECT <include refid="columns"/> FROM member 
@@ -115,4 +120,10 @@
 	<delete id="delete" parameterType="int">
 		DELETE FROM member WHERE member_id = #{member_id}
 	</delete>
+	
+	<!-- 총 레코드 수 -->
+	<select id="totalRecord" resultType="int">
+		SELECT COUNT(member_id) FROM member
+	</select>
+	
 </mapper>

--- a/shoppingmall/src/main/java/shoppingmall/mybatis/OrderSummaryMapper.xml
+++ b/shoppingmall/src/main/java/shoppingmall/mybatis/OrderSummaryMapper.xml
@@ -27,13 +27,13 @@
 		WHERE status_id &lt; 6
 		ORDER BY ordered_at DESC LIMIT #{page_size} OFFSET #{offset}
 	</select>
-	
+	<!-- 교환내역 조회 -->
 	<select id="selectByInquiry" parameterType="map" resultMap="DetailJoin">
 		SELECT <include refid="columns"/> FROM order_summary
 		WHERE status_id = 7
 		ORDER BY ordered_at DESC LIMIT #{page_size} OFFSET #{offset}
 	</select>
-	
+	<!-- 반품내역 조회 -->
 	<select id="selectByReturn" parameterType="map" resultMap="DetailJoin">
 		SELECT <include refid="columns"/> FROM order_summary
 		WHERE status_id = 6
@@ -98,14 +98,14 @@
 
 	<select id="totalRecord" parameterType="Status" resultType="int">
 		SELECT COUNT(order_summary_id) FROM order_summary
-
-		<if test="status_id != 0 and status_id lt 6">
-			WHERE status_id &lt; ${status_id}
-		</if>
-
-		<if test="status_id != 0 and status_id gt 5">
-			WHERE status_id = #{status_id}
-		</if>
+		<where>
+			<if test="status_id != 0 and status_id lt 6">
+				status_id &lt;= #{status_id}
+			</if>
+			<if test="status_id != 0 and status_id gte 6">
+				status_id = #{status_id}
+			</if>
+		</where>
 	</select>
 
 </mapper>

--- a/shoppingmall/src/main/java/shoppingmall/mybatis/ProductMapper.xml
+++ b/shoppingmall/src/main/java/shoppingmall/mybatis/ProductMapper.xml
@@ -108,7 +108,7 @@
 	</update>
 	
 	<!-- 한 건 삭제하기 -->
-	<delete id="delete" parameterType="int">
+	<delete id="delete" parameterType="Product">
 	 	delete from product where product_id=#{product_id}
 	</delete>
 	

--- a/shoppingmall/src/main/java/shoppingmall/mybatis/QnaMapper.xml
+++ b/shoppingmall/src/main/java/shoppingmall/mybatis/QnaMapper.xml
@@ -49,12 +49,18 @@
 		<result column="comment" 		property="comment"/>
 		<result column="is_commented"	property="is_commented"/>
 		
-		<association column="product_id" property="product" javaType="Product" select="Product.select"/>
+		<association column="product_id" property="product" javaType="Product" select="Product.selectOnlyProduct"/>
+		<association column="member_id" property="member" javaType="Member" select="Member.selectOnlyMember"/>
 	</resultMap>
 	
 	<!-- Member(부모)에 의한 호출 리스트 -->
 	<select id="selectQnaByMemberId" parameterType="int" resultMap="QnaMemberJoin">
 		SELECT <include refid="columns"/> FROM qna WHERE member_id = #{member_id}
+	</select>
+	
+	<!-- 전체 레코드 가져오기 -->
+	<select id="totalRecord" resultType="int">
+		SELECT COUNT(qna_id) FROM qna; 
 	</select>
 		
 	<!-- Qna 등록 -->	

--- a/shoppingmall/src/main/webapp/WEB-INF/views/management/cs/qna/list.jsp
+++ b/shoppingmall/src/main/webapp/WEB-INF/views/management/cs/qna/list.jsp
@@ -1,7 +1,9 @@
+<%@page import="shoppingmall.util.Paging"%>
 <%@page import="shoppingmall.domain.Qna"%>
 <%@page import="java.util.List"%>
 <%@ page contentType="text/html; charset=UTF-8"%>
 <% List<Qna> qnas = (List<Qna>) request.getAttribute("qnas"); %>
+<% Paging paging = (Paging) request.getAttribute("paging"); %>
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -131,19 +133,36 @@
 									</div>
 									<div class="row justify-content-between">
 										<div class="col-sm-12 col-md-auto">
-											<div class="dataTables_info" id="example2_info" role="status" aria-live="polite">총 57 페이지</div>
+											<div class="dataTables_info" id="example2_info" role="status" aria-live="polite">총 <%= paging.getTotalPage() %> 페이지</div>
 										</div>
 										<div class="col-sm-12 col-md-auto">
 											<div class="dataTables_paginate paging_simple_numbers" id="example2_paginate">
 												<ul class="pagination">
+													<%
+													if (paging.getFirstPage() - 1 > 0) {
+													%>
+													<li class="paginate_button page-item previous" id="example2_previous"><a href="<%= contextPath %>/admin/cs/qna/listpage?pagenum=<%= paging.getCurPos() - 1 %>" aria-controls="example2" data-dt-idx="0" tabindex="0" class="page-link">Previous</a></li>
+													<%
+													} else {
+													%>
 													<li class="paginate_button page-item previous disabled" id="example2_previous"><a href="#" aria-controls="example2" data-dt-idx="0" tabindex="0" class="page-link">Previous</a></li>
-													<li class="paginate_button page-item active"><a href="#" aria-controls="example2" data-dt-idx="1" tabindex="0" class="page-link">1</a></li>
-													<li class="paginate_button page-item"><a href="#" aria-controls="example2" data-dt-idx="2" tabindex="0" class="page-link">2</a></li>
-													<li class="paginate_button page-item"><a href="#" aria-controls="example2" data-dt-idx="3" tabindex="0" class="page-link">3</a></li>
-													<li class="paginate_button page-item"><a href="#" aria-controls="example2" data-dt-idx="4" tabindex="0" class="page-link">4</a></li>
-													<li class="paginate_button page-item"><a href="#" aria-controls="example2" data-dt-idx="5" tabindex="0" class="page-link">5</a></li>
-													<li class="paginate_button page-item"><a href="#" aria-controls="example2" data-dt-idx="6" tabindex="0" class="page-link">6</a></li>
-													<li class="paginate_button page-item next" id="example2_next"><a href="#" aria-controls="example2" data-dt-idx="7" tabindex="0" class="page-link">Next</a></li>
+													<% } %>
+													
+													<% for(int i = paging.getFirstPage(); i <= paging.getLastPage(); i++) { 
+														if(i > paging.getTotalPage()) break;
+													%>
+														<li class="paginate_button page-item <% if(i == paging.getCurrentPage()) { out.print("active"); } %>"><a href="<%= contextPath %>/admin/cs/qna/listpage?pagenum=<%=i%>" aria-controls="example2" data-dt-idx="1" tabindex="0" class="page-link"><%= i %></a></li>
+													<% } %>
+													<%
+													if (paging.getLastPage() < paging.getTotalPage()) {
+													%>
+													<li class="paginate_button page-item next" id="example2_next"><a href="<%= contextPath %>/admin/cs/qna/listpage?pagenum=<%= paging.getCurPos() + 1 %>" aria-controls="example2" data-dt-idx="7" tabindex="0" class="page-link">Next</a></li>
+													<%
+													} else {
+													%>
+													<li class="paginate_button page-item next disabled" id="example2_next"><a href="#" aria-controls="example2" data-dt-idx="7" tabindex="0" class="page-link">Next</a></li>
+													<% } %>
+													
 												</ul>
 											</div>
 										</div>

--- a/shoppingmall/src/main/webapp/WEB-INF/views/management/inc/left_bar.jsp
+++ b/shoppingmall/src/main/webapp/WEB-INF/views/management/inc/left_bar.jsp
@@ -1,6 +1,6 @@
 <%@page import="shoppingmall.domain.Member"%>
 <%@ page contentType="text/html; charset=UTF-8"%>
-<% String navMaenu = (String)request.getAttribute("navMenu"); %>
+<% String navMenu = (String)request.getAttribute("navMenu"); %>
 <% Member loginAdmin = (Member) session.getAttribute("loginAdmin"); %>
   <aside class="main-sidebar sidebar-dark-primary elevation-4">
     <!-- Brand Logo -->
@@ -25,8 +25,8 @@
                with font-awesome or any other icon font library -->
          
           <!-- 주문관리 메뉴 시작-->
-          <li class="nav-item <%= (navMaenu != null && navMaenu.startsWith("order")) ? "menu-is-opening menu-open" : "" %>">
-            <a href="#" class="nav-link <%= (navMaenu != null && navMaenu.startsWith("order")) ? "active" : "" %>">
+          <li class="nav-item <%= (navMenu != null && navMenu.startsWith("order")) ? "menu-is-opening menu-open" : "" %>">
+            <a href="#" class="nav-link <%= (navMenu != null && navMenu.startsWith("order")) ? "active" : "" %>">
               <i class="nav-icon fas fa-tachometer-alt"></i>
               <p>
                주문관리
@@ -35,19 +35,19 @@
             </a>
             <ul class="nav nav-treeview">
               <li class="nav-item">
-                <a href="<%=contextPath %>/admin/order/history/listpage?status_id=1" id="orderHistory" class="nav-link <%= "orderHistory".equals(navMaenu) ? "active" : "" %>">
+                <a href="<%=contextPath %>/admin/order/history/listpage?status_id=1" id="orderHistory" class="nav-link <%= "orderHistory".equals(navMenu) ? "active" : "" %>">
                   <i class="far fa-circle nav-icon"></i>
                   <p>주문</p>
                 </a>
               </li>
                <li class="nav-item">
-                <a href="<%=contextPath %>/admin/order/inquiry/listpage?status_id=7" id="orderInquiry" class="nav-link <%= "orderInquiry".equals(navMaenu) ? "active" : "" %>">
+                <a href="<%=contextPath %>/admin/order/inquiry/listpage?status_id=7" id="orderInquiry" class="nav-link <%= "orderInquiry".equals(navMenu) ? "active" : "" %>">
                   <i class="far fa-circle nav-icon"></i>
                   <p>교환</p>
                 </a>
               </li>
               <li class="nav-item">
-                <a href="<%=contextPath %>/admin/order/return/listpage?status_id=6" id="orderReturn" class="nav-link <%= "orderReturn".equals(navMaenu) ? "active" : "" %>">
+                <a href="<%=contextPath %>/admin/order/return/listpage?status_id=6" id="orderReturn" class="nav-link <%= "orderReturn".equals(navMenu) ? "active" : "" %>">
                   <i class="far fa-circle nav-icon"></i>
                   <p>반품</p>
                 </a>
@@ -58,7 +58,7 @@
       
           <!-- 상품관리 메뉴 시작-->
           <li class="nav-item">
-            <a href="<%=contextPath%>/admin/product/listpage" class="nav-link <%= (navMaenu != null && navMaenu.startsWith("productList")) ? "active" : "" %>">
+            <a href="<%=contextPath%>/admin/product/listpage" class="nav-link <%= (navMenu != null && navMenu.startsWith("productList")) ? "active" : "" %>">
               <i class="nav-icon fas fa-tachometer-alt"></i>
               <p>
                 상품관리
@@ -68,8 +68,8 @@
           <!-- 상품관리 메뉴 끝-->
       
           <!--회원관리 메뉴 시작-->
-          <li class="nav-item <%= (navMaenu != null && navMaenu.startsWith("member")) ? "menu-is-opening menu-open" : "" %>">
-            <a href="#" class="nav-link <%= (navMaenu != null && navMaenu.startsWith("member")) ? "active" : "" %>">
+          <li class="nav-item <%= (navMenu != null && navMenu.startsWith("member")) ? "menu-is-opening menu-open" : "" %>">
+            <a href="#" class="nav-link <%= (navMenu != null && navMenu.startsWith("member")) ? "active" : "" %>">
               <i class="nav-icon fas fa-tachometer-alt"></i>
               <p>
                 회원관리
@@ -78,7 +78,7 @@
             </a>
             <ul class="nav nav-treeview">
               <li class="nav-item">
-                <a href="<%= contextPath%>/admin/member/list" class="nav-link <%= (navMaenu != null && navMaenu.startsWith("memberList")) ? "active" : "" %>">
+                <a href="<%= contextPath%>/admin/member/listpage" class="nav-link <%= (navMenu != null && navMenu.startsWith("memberList")) ? "active" : "" %>">
                   <i class="far fa-circle nav-icon"></i>
                   <p>회원목록</p>
                 </a>
@@ -94,8 +94,8 @@
           <!--회원관리 메뉴 끝-->
       
           <!--고객센터 메뉴 시작-->
-          <li class="nav-item <%= (navMaenu != null && navMaenu.startsWith("cs")) ? "menu-is-opening menu-open" : "" %>">
-            <a href="#" class="nav-link <%= (navMaenu != null && navMaenu.startsWith("cs")) ? "active" : "" %>">
+          <li class="nav-item <%= (navMenu != null && navMenu.startsWith("cs")) ? "menu-is-opening menu-open" : "" %>">
+            <a href="#" class="nav-link <%= (navMenu != null && navMenu.startsWith("cs")) ? "active" : "" %>">
               <i class="nav-icon fas fa-tachometer-alt"></i>
               <p>
                고객센터
@@ -104,7 +104,7 @@
             </a>
             <ul class="nav nav-treeview">
               <li class="nav-item">
-                <a href="<%= contextPath%>/admin/cs/qna/listpage" class="nav-link <%= (navMaenu != null && navMaenu.startsWith("csQnaList")) ? "active" : "" %>">
+                <a href="<%= contextPath%>/admin/cs/qna/listpage" class="nav-link <%= (navMenu != null && navMenu.startsWith("csQnaList")) ? "active" : "" %>">
                   <i class="far fa-circle nav-icon"></i>
                   <p>QnA</p>
                 </a>

--- a/shoppingmall/src/main/webapp/WEB-INF/views/management/member/detail.jsp
+++ b/shoppingmall/src/main/webapp/WEB-INF/views/management/member/detail.jsp
@@ -7,7 +7,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>상품 관리</title>
+<title>SinseBoardGame | 회원상세</title>
 <%@ include file="../inc/head_link.jsp"%>
 </head>
 <body class="hold-transition sidebar-mini layout-fixed">
@@ -26,14 +26,14 @@
 				<div class="container-fluid">
 					<div class="row mb-2">
 						<div class="col-sm-6">
-							<h1 class="m-0">Dashboard</h1>
+							<h1 class="m-0">회원상세</h1>
 						</div>
 						<!-- /.col -->
 						<div class="col-sm-6">
 							<ol class="breadcrumb float-sm-right">
 								<li class="breadcrumb-item"><a href="#">Home</a></li>
 								<li class="breadcrumb-item">회원관리</li>
-								<li class="breadcrumb-item active">상세보기</li>
+								<li class="breadcrumb-item active">회원상세</li>
 							</ol>
 						</div>
 						<!-- /.col -->
@@ -126,7 +126,6 @@
 								<ul class="nav nav-tabs">
 									<li class="nav-item"><summary class="nav-link active font-weight-bold">주문 내역</summary></li>
 									<li class="nav-item"><summary class="nav-link">문의 내역</summary></li>
-									<li class="nav-item"><summary class="nav-link">반품 내역</summary></li>
 								</ul>
 								<!-- 테이블 시작 -->
 								<div id="table-wrapper" class="dataTables_wrapper dt-bootstrap4">
@@ -159,15 +158,13 @@
     function createOrderHistoryTable(json) {
       // 헤더 정보 배열
       const headers = [
-        { text: '대표 이미지', width: '120px', class: 'sorting sorting_asc', ariaSort: 'ascending' },
-        { text: '상품명', class: 'sorting' },
-        { text: '가격', class: 'sorting' },
-        { text: '할인율', class: 'sorting' },
-        { text: '재고', class: 'sorting' },
-        { text: '카테고리', class: 'sorting' },
-        { text: '연령', class: 'sorting' },
-        { text: '등록일자', class: 'sorting' },
-        { text: '비고', class: 'sorting' }
+        { text: '주문번호', width: '120px', class: 'sorting sorting_asc', ariaSort: 'ascending' },
+        { text: '구매일자', class: 'sorting' },
+        { text: '총 결제금액', class: 'sorting' },
+        { text: '결제수단', class: 'sorting' },
+        { text: '회원', class: 'sorting' },
+        { text: '상태', class: 'sorting' },
+        { text: '비고', class: 'sorting' },
       ];
 
       // 테이블 헤드와 행 생성
@@ -193,44 +190,144 @@
         $headerRow.append($th);
       });
 
+      const $tbody = $('<tbody>');
+      
       if (json) {
-
-      } else {
-
+        for(let i = 0; i < json.length; i++) {
+          const order = json[i];
+          const $bodyRow = $('<tr class="odd">');
+          
+          $bodyRow.append($('<td class="dtr-control sorting_1 text-right" tabindex="0">').text(order.order_summary_id));
+          $bodyRow.append($('<td class="text-right">').text(order.ordered_at));
+          $bodyRow.append($('<td class="text-right">').text(order.total_price + '원'));
+          $bodyRow.append($('<td class="text-right">').text(order.payment_type));
+          $bodyRow.append($('<td class="text-right">').text(order.member.member_name));
+          
+          let buttonClass = 'btn-primary';
+          switch(order.status.status_id) {
+            case 1: buttonClass = 'btn-secondary'; break;
+            case 2: buttonClass = 'btn btn-light'; break;
+            case 3: buttonClass = 'btn-dark'; break;
+            case 4: buttonClass = 'btn btn-info'; break;
+            case 5: buttonClass = 'btn-success'; break;
+            case 6: buttonClass = 'btn-danger'; break;
+            default: buttonClass = 'btn-warning'; break;
+          }
+          
+          const $statusCell = $('<td class="text-right">');
+          $statusCell.append($('<button type="button" class="btn btn-block ' + buttonClass + ' btn-sm">').text(order.status.status_name));
+          $bodyRow.append($statusCell);
+          
+          const $actionCell = $('<td class="text-right">');
+          const $detailLink = $('<a href="/admin/order/history/detail?order_summery_id=' + order.order_summary_id + '">');
+          $detailLink.append($('<button type="button" class="btn btn-block btn-primary btn-sm">').text('상세보기'));
+          $actionCell.append($detailLink);
+          $bodyRow.append($actionCell);
+          
+          $tbody.append($bodyRow);
+        }
       }
 
       $thead.append($headerRow);
-      $("#history-table").html($thead);
+      const $table = $('<table>').append($thead).append($tbody);
+      $("#history-table").html($table.html());
     }
 
     function getOrderHistory() {
       $.ajax({
-        url: "/admin/order/histoy/list",
+        url: "/admin/order/history/list?member_id=<%= member.getMember_id()%>",
         type: "get",
         success: (result, status, xhr) => {
-          createOrderHistoryTable(result);
+			/* console.log(result); */
+			const json = JSON.parse(result);
+          	createOrderHistoryTable(json);
         },
         error: (xhr, status, error) => {
-          createOrderHistoryTable();
+            console.log(error);
+          	createOrderHistoryTable();
         },
       })
     }
-    function getInquiryHistory() {
+    function createQnaHistoryTable(json) {
+      // 헤더 정보 배열
+      const headers = [
+        { text: '답변상태', width: '120px', class: 'sorting sorting_asc', ariaSort: 'ascending' },
+        { text: '제목', class: 'sorting' },
+        { text: '작성자', class: 'sorting' },
+        { text: '상품명', class: 'sorting' },
+        { text: '비고', class: 'sorting' },
+      ];
+
+      // 테이블 헤드와 행 생성
+      const $thead = $('<thead>');
+      const $headerRow = $('<tr>');
+
+      // 각 헤더 생성
+      headers.forEach(header => {
+        const thOptions = {
+          class: header.class,
+          tabindex: '0',
+          'aria-controls': 'example2',
+          rowspan: '1',
+          colspan: '1',
+          'aria-label': `${header.text}: activate to sort column ascending`,
+          text: header.text
+        };
+
+        if (header.width) thOptions.width = header.width;
+        if (header.ariaSort) thOptions['aria-sort'] = header.ariaSort;
+
+        const $th = $('<th>', thOptions);
+        $headerRow.append($th);
+      });
+
+      const $tbody = $('<tbody>');
+      
+      if (json) {
+        for(let i = 0; i < json.length; i++) {
+          const qna = json[i];
+          const $bodyRow = $('<tr class="odd">');
+          
+          let statusText = '답변대기';
+          if (qna.is_commented == 1) {
+            statusText = '답변완료';
+          }
+          
+          $bodyRow.append($('<td class="dtr-control sorting_1 text-right align-middle" tabindex="0">').text(statusText));
+          $bodyRow.append($('<td class="text-right align-middle">').text(qna.content));
+          $bodyRow.append($('<td class="text-right align-middle">').text(qna.member.member_name));
+          $bodyRow.append($('<td class="text-right align-middle">').text(qna.product.product_name));
+          
+          const $actionCell = $('<td class="text-right align-middle">');
+          const $detailLink = $('<a href="/admin/cs/qna/detail?qna_id=' + qna.qna_id + '">');
+          $detailLink.append($('<button type="button" class="btn btn-block btn-primary btn-sm">').text('상세보기'));
+          $actionCell.append($detailLink);
+          $bodyRow.append($actionCell);
+          
+          $tbody.append($bodyRow);
+        }
+      }
+
+      $thead.append($headerRow);
+      const $table = $('<table>').append($thead).append($tbody);
+      $("#history-table").html($table.html());
+    }
+
+    function getQnAHistory() {
       $.ajax({
-        url: "/admin/order/inquiry/list",
+        url: "/admin/cs/qna/list?member_id=<%= member.getMember_id()%>",
         type: "get",
-        success: (result, status, xhr) => { },
-        error: (xhr, status, error) => { },
+        success: (result, status, xhr) => {
+          const json = JSON.parse(result);
+          createQnaHistoryTable(json);
+        },
+        error: (xhr, status, error) => {
+          console.log(error);
+          createQnaHistoryTable();
+        },
       })
     }
-    function getReturnHistory() {
-      $.ajax({
-        url: "/admin/order/return/list",
-        type: "get",
-        success: (result, status, xhr) => { },
-        error: (xhr, status, error) => { },
-      })
-    }
+    
     //Date picker
     $("#reservationdate").datetimepicker({
       format: "YYYY-MM-DD",
@@ -249,9 +346,7 @@
         switch (index) {
           case 0: getOrderHistory();
             break;
-          case 1: getInquiryHistory();
-            break;
-          default: getReturnHistory();
+          default : getQnAHistory();
             break;
         }
         // 모든 summary에서 active, font-weight-bold 클래스 제거

--- a/shoppingmall/src/main/webapp/WEB-INF/views/management/member/list.jsp
+++ b/shoppingmall/src/main/webapp/WEB-INF/views/management/member/list.jsp
@@ -9,7 +9,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>상품 관리</title>
+<title>SinseBoardGame | 회원관리</title>
 <%@ include file="../inc/head_link.jsp"%>
 </head>
 <body class="hold-transition sidebar-mini layout-fixed">
@@ -29,13 +29,14 @@
 				<div class="container-fluid">
 					<div class="row mb-2">
 						<div class="col-sm-6">
-							<h1 class="m-0">상품 등록</h1>
+							<h1 class="m-0">회원목록</h1>
 						</div>
 						<!-- /.col -->
 						<div class="col-sm-6">
 							<ol class="breadcrumb float-sm-right">
 								<li class="breadcrumb-item"><a href="#">Home</a></li>
-								<li class="breadcrumb-item active">상품관리>상품등록</li>
+								<li class="breadcrumb-item">회원관리</li>
+								<li class="breadcrumb-item active">회원목록</li>
 							</ol>
 						</div>
 						<!-- /.col -->

--- a/shoppingmall/src/main/webapp/WEB-INF/views/management/member/list.jsp
+++ b/shoppingmall/src/main/webapp/WEB-INF/views/management/member/list.jsp
@@ -1,7 +1,9 @@
+<%@page import="shoppingmall.util.Paging"%>
 <%@page import="shoppingmall.domain.Member"%>
 <%@page import="java.util.List"%>
 <%@ page contentType="text/html; charset=UTF-8"%>
 <% List<Member> members = (List<Member>)request.getAttribute("members"); %>
+<% Paging paging = (Paging) request.getAttribute("paging"); %>
 <!DOCTYPE html>
 <html lang="ko">
 <head>
@@ -141,19 +143,36 @@
 									</div>
 									<div class="row justify-content-between">
 										<div class="col-sm-12 col-md-auto">
-											<div class="dataTables_info" id="example2_info" role="status" aria-live="polite">총 57 페이지</div>
+											<div class="dataTables_info" id="example2_info" role="status" aria-live="polite">총 <%= paging.getTotalPage() %> 페이지</div>
 										</div>
 										<div class="col-sm-12 col-md-auto">
 											<div class="dataTables_paginate paging_simple_numbers" id="example2_paginate">
 												<ul class="pagination">
+													<%
+													if (paging.getFirstPage() - 1 > 0) {
+													%>
+													<li class="paginate_button page-item previous" id="example2_previous"><a href="<%= contextPath %>/admin/member/listpage?pagenum=<%= paging.getCurPos() - 1 %>" aria-controls="example2" data-dt-idx="0" tabindex="0" class="page-link">Previous</a></li>
+													<%
+													} else {
+													%>
 													<li class="paginate_button page-item previous disabled" id="example2_previous"><a href="#" aria-controls="example2" data-dt-idx="0" tabindex="0" class="page-link">Previous</a></li>
-													<li class="paginate_button page-item active"><a href="#" aria-controls="example2" data-dt-idx="1" tabindex="0" class="page-link">1</a></li>
-													<li class="paginate_button page-item"><a href="#" aria-controls="example2" data-dt-idx="2" tabindex="0" class="page-link">2</a></li>
-													<li class="paginate_button page-item"><a href="#" aria-controls="example2" data-dt-idx="3" tabindex="0" class="page-link">3</a></li>
-													<li class="paginate_button page-item"><a href="#" aria-controls="example2" data-dt-idx="4" tabindex="0" class="page-link">4</a></li>
-													<li class="paginate_button page-item"><a href="#" aria-controls="example2" data-dt-idx="5" tabindex="0" class="page-link">5</a></li>
-													<li class="paginate_button page-item"><a href="#" aria-controls="example2" data-dt-idx="6" tabindex="0" class="page-link">6</a></li>
-													<li class="paginate_button page-item next" id="example2_next"><a href="#" aria-controls="example2" data-dt-idx="7" tabindex="0" class="page-link">Next</a></li>
+													<% } %>
+													
+													<% for(int i = paging.getFirstPage(); i <= paging.getLastPage(); i++) { 
+														if(i > paging.getTotalPage()) break;
+													%>
+														<li class="paginate_button page-item <% if(i == paging.getCurrentPage()) { out.print("active"); } %>"><a href="<%= contextPath %>/admin/member/listpage?pagenum=<%=i%>" aria-controls="example2" data-dt-idx="1" tabindex="0" class="page-link"><%= i %></a></li>
+													<% } %>
+													<%
+													if (paging.getLastPage() < paging.getTotalPage()) {
+													%>
+													<li class="paginate_button page-item next" id="example2_next"><a href="<%= contextPath %>/admin/member/listpage?pagenum=<%= paging.getCurPos() + 1 %>" aria-controls="example2" data-dt-idx="7" tabindex="0" class="page-link">Next</a></li>
+													<%
+													} else {
+													%>
+													<li class="paginate_button page-item next disabled" id="example2_next"><a href="#" aria-controls="example2" data-dt-idx="7" tabindex="0" class="page-link">Next</a></li>
+													<% } %>
+													
 												</ul>
 											</div>
 										</div>

--- a/shoppingmall/src/main/webapp/WEB-INF/views/management/order/detail.jsp
+++ b/shoppingmall/src/main/webapp/WEB-INF/views/management/order/detail.jsp
@@ -1,10 +1,14 @@
+<%@page import="shoppingmall.domain.OrderDetail"%>
+<%@page import="shoppingmall.domain.OrderSummary"%>
 <%@ page contentType="text/html; charset=UTF-8"%>
+<%  OrderSummary orderSummary = (OrderSummary) request.getAttribute("orderSummary"); %>
+<%  int totalPrice = 0; %>
 <!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>AdminLTE 3 | Dashboard</title>
+<title>SinseBoardGame | 주문상세</title>
 <%@ include file="../inc/head_link.jsp"%>
 </head>
 <body class="hold-transition sidebar-mini layout-fixed">
@@ -24,33 +28,35 @@
 							<p class="h2">주문 상품</p>
 						</div>
 						<div class="card-body">
+						<% for(int i = 0; i < orderSummary.getOrderDetailList().size(); i++) { 
+								OrderDetail orderDetail = orderSummary.getOrderDetailList().get(i);
+								totalPrice += (int)((orderDetail.getProductSnapshot().getPrice() - (orderDetail.getProductSnapshot().getPrice() * (orderDetail.getProductSnapshot().getDiscount_rate()/(float)100))) * orderDetail.getQuantity_real());
+						%>
+						
 							<!-- 상품 아이템 시작-->
 							<div class="d-flex">
 								<img src="./상품이미지.png" alt="" />
 								<div class="d-flex flex-column ml-3 justify-content-between">
-									<p class="h3">사보타지</p>
-									<p class="font-weight-bold text-lg" style="color: brown">40%</p>
+									<p class="h3"><%= orderDetail.getProductSnapshot().getProduct_name() %></p>
+									<p class="font-weight-bold text-lg" style="color: brown"><%= orderDetail.getProductSnapshot().getDiscount_rate() %>%</p>
 									<p class="font-weight-bold">
-										수량 : <span>2</span>개
+										수량 : <span><%= orderDetail.getQuantity_real() %></span>개
 									</p>
-									<p style="color: lightslategray">2025-06-10 12:12 주문</p>
+									<p style="color: lightslategray"><%= orderSummary.getOrdered_at() %> 주문</p>
+									<% if(orderDetail.getProductSnapshot().getDiscount_rate() > 0) { %>
+										<p class="h5"style="color: lightslategray"><del><%= orderDetail.getProductSnapshot().getPrice() %>원</del></p>
+									<% } %>
+									<p class="h4"><%= (int)((orderDetail.getProductSnapshot().getPrice() - (orderDetail.getProductSnapshot().getPrice() * (orderDetail.getProductSnapshot().getDiscount_rate()/(float)100)))) %>원</p>
 								</div>
 							</div>
 							<!-- 상품 아이템 끝 -->
 							<hr />
-							<!-- 상품 아이템 시작-->
-							<div class="d-flex">
-								<img src="./상품이미지.png" alt="" />
-								<div class="d-flex flex-column ml-3 justify-content-between">
-									<p class="h3">사보타지</p>
-									<p class="font-weight-bold text-lg" style="color: brown">40%</p>
-									<p class="font-weight-bold">
-										수량 : <span>2</span>개
-									</p>
-									<p style="color: lightslategray">2025-06-10 12:12 주문</p>
-								</div>
+							<% } %>
+							<div>
+							<p>포인트 사용 : <span class="h4 font-weight-bold"><%= orderSummary.getPoint_used() %>p</span></p>
 							</div>
-							<!-- 상품 아이템 끝 -->
+							<hr />
+							<div class = "h3">결제 금액 : <%=totalPrice - orderSummary.getPoint_used() %>원</div>
 						</div>
 					</div>
 				</div>
@@ -64,15 +70,15 @@
 						<div class="d-flex flex-column">
 							<div class="d-flex flex-column">
 								<p class="h4">수령자</p>
-								<input type="text" class="form-control" id="exampleInputEmail1" placeholder="Enter email" value="홍길동" readonly />
+								<input type="text" class="form-control" id="exampleInputEmail1" value="<%= orderSummary.getDelivery().getReceiver_name() %>" readonly />
 							</div>
 							<div class="d-flex flex-column">
 								<p class="h4 mt-3">연락처</p>
-								<input type="text" class="form-control" id="exampleInputEmail1" placeholder="Enter email" value="010-1234-1234" readonly />
+								<input type="text" class="form-control" id="exampleInputEmail1" value="<%= orderSummary.getDelivery().getReceiver_phone() %>" readonly />
 							</div>
 							<div class="d-flex flex-column">
 								<p class="h4 mt-3">배송지</p>
-								<input type="text" class="form-control" id="exampleInputEmail1" placeholder="Enter email" value="서울시 강남구 블라블라동" readonly />
+								<input type="text" class="form-control" id="exampleInputEmail1" value="<%= orderSummary.getDelivery().getAddress()%>" readonly />
 							</div>
 						</div>
 					</div>

--- a/shoppingmall/src/main/webapp/WEB-INF/views/management/order/history.jsp
+++ b/shoppingmall/src/main/webapp/WEB-INF/views/management/order/history.jsp
@@ -1,3 +1,4 @@
+<%@page import="shoppingmall.domain.ProductSnapshot"%>
 <%@page import="shoppingmall.util.Paging"%>
 <%@page import="shoppingmall.domain.OrderSummary"%>
 <%@page import="java.util.List"%>
@@ -9,7 +10,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>AdminLTE 3 | Dashboard</title>
+<title>SinseBoardGame | 주문내역</title>
 <%@ include file="../inc/head_link.jsp"%>
 </head>
 <body class="hold-transition sidebar-mini layout-fixed">
@@ -103,12 +104,17 @@
 											<tbody>
 											<% for(int i = 0; i < orderSummaries.size(); i++) {
 												OrderSummary orderSummary = orderSummaries.get(i);
+												int paymentPrice = 0;
+												for(int j = 0; j < orderSummary.getOrderDetailList().size(); j++) {
+													ProductSnapshot productSnapshot = orderSummary.getOrderDetailList().get(j).getProductSnapshot();
+													paymentPrice += (int)(productSnapshot.getPrice() - (productSnapshot.getPrice() * (productSnapshot.getDiscount_rate()/(float)100)));
+												}
 												%>
 												<!-- 테이블 아이템 시작 -->
 												<tr class="odd">
 													<td class="dtr-control sorting_1 text-right" tabindex="0"><%= orderSummary.getOrder_summary_id() %></td>
 													<td class="text-right"><%= orderSummary.getOrdered_at() %></td>
-													<td class="text-right"><%= orderSummary.getTotal_price() %>원</td>
+													<td class="text-right"><%= paymentPrice %>원</td>
 													<td class="text-right"><%= orderSummary.getPoint_used() %>p</td>
 													<td class="text-right"><%= orderSummary.getPayment_type() %></td>
 													<td class="text-right"><%= orderSummary.getMember().getMember_name() %></td>
@@ -142,7 +148,7 @@
 														<button type="button" class="btn btn-block <%= buttonClassName %> btn-sm"><%= orderSummary.getStatus().getStatus_name() %></button>
 													</td>
 													<td class="text-right">
-														<button type="button" class="btn btn-block btn-primary btn-sm">상세보기</button>
+														<a href="/admin/order/history/detail?order_summery_id=<%= orderSummary.getOrder_summary_id()%>"><button type="button" class="btn btn-block btn-primary btn-sm">상세보기</button></a>
 													</td>
 												</tr>
 												<!-- 테이블 아이템 끝 -->

--- a/shoppingmall/src/main/webapp/WEB-INF/views/management/order/inquiry.jsp
+++ b/shoppingmall/src/main/webapp/WEB-INF/views/management/order/inquiry.jsp
@@ -1,10 +1,16 @@
+<%@page import="shoppingmall.domain.ProductSnapshot"%>
+<%@page import="shoppingmall.util.Paging"%>
+<%@page import="shoppingmall.domain.OrderSummary"%>
+<%@page import="java.util.List"%>
 <%@ page contentType="text/html; charset=UTF-8"%>
+<% List<OrderSummary> orderSummaries = (List<OrderSummary>) request.getAttribute("orderSummaries"); %>
+<% Paging paging = (Paging) request.getAttribute("paging"); %>
 <!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>AdminLTE 3 | Dashboard</title>
+<title>SinseBoardGame | 교환내역</title>
 <%@ include file="../inc/head_link.jsp"%>
 </head>
 <body class="hold-transition sidebar-mini layout-fixed">
@@ -23,13 +29,13 @@
 				<div class="container-fluid">
 					<div class="row mb-2">
 						<div class="col-sm-6">
-							<h1 class="m-0">주문내역</h1>
+							<h1 class="m-0">교환내역</h1>
 						</div>
 						<!-- /.col -->
 						<div class="col-sm-6">
 							<ol class="breadcrumb float-sm-right">
 								<li class="breadcrumb-item"><a href="#">Home</a></li>
-								<li class="breadcrumb-item active">주문내역</li>
+								<li class="breadcrumb-item active">교환내역</li>
 							</ol>
 						</div>
 						<!-- /.col -->
@@ -96,38 +102,58 @@
 											<!-- 테이블 헤더 끝 -->
 											<!-- 테이블 바디 시작 -->
 											<tbody>
+													<% for(int i = 0; i < orderSummaries.size(); i++) {
+												OrderSummary orderSummary = orderSummaries.get(i);
+												int paymentPrice = 0;
+												for(int j = 0; j < orderSummary.getOrderDetailList().size(); i++) {
+													ProductSnapshot productSnapshot = orderSummary.getOrderDetailList().get(i).getProductSnapshot();
+													paymentPrice += (int)(productSnapshot.getPrice() - (productSnapshot.getPrice() * (productSnapshot.getDiscount_rate()/(float)100)));
+												}
+												
+												%>
 												<!-- 테이블 아이템 시작 -->
 												<tr class="odd">
-													<td class="dtr-control sorting_1 text-right" tabindex="0">000200002</td>
-													<td class="text-right">2025-06-17 20:23:17</td>
-													<td class="text-right">20,000원</td>
-													<td class="text-right">2000p</td>
-													<td class="text-right">신용카드</td>
-													<td class="text-right">testuser1</td>
+													<td class="dtr-control sorting_1 text-right" tabindex="0"><%= orderSummary.getOrder_summary_id() %></td>
+													<td class="text-right"><%= orderSummary.getOrdered_at() %></td>
+													<td class="text-right"><%= paymentPrice %>원</td>
+													<td class="text-right"><%= orderSummary.getPoint_used() %>p</td>
+													<td class="text-right"><%= orderSummary.getPayment_type() %></td>
+													<td class="text-right"><%= orderSummary.getMember().getMember_name() %></td>
 													<td class="text-right">
-														<button type="button" class="btn btn-block btn-danger btn-sm">결제 취소</button>
+														<% 
+															String buttonClassName = "btn-primary";
+															switch(orderSummary.getStatus().getStatus_id()){
+															case 1:
+																buttonClassName = "btn-secondary";
+																break;
+															case 2:
+																buttonClassName = "btn btn-ligh";
+																break;
+															case 3:
+																buttonClassName = "btn-dark";
+																break;
+															case 4:
+																buttonClassName = "btn btn-info";
+																break;
+															case 5:
+																buttonClassName = "btn-success";
+																break;
+															case 6:
+																buttonClassName = "btn-danger";
+																break;
+															default: 
+																buttonClassName = "btn-warning";
+																break;
+															}
+														%>
+														<button type="button" class="btn btn-block <%= buttonClassName %> btn-sm"><%= orderSummary.getStatus().getStatus_name() %></button>
 													</td>
 													<td class="text-right">
-														<button type="button" class="btn btn-block btn-primary btn-sm">상세보기</button>
+														<a href="/admin/order/inquiry/detail?order_summery_id=<%= orderSummary.getOrder_summary_id()%>"><button type="button" class="btn btn-block btn-primary btn-sm">상세보기</button></a>
 													</td>
 												</tr>
 												<!-- 테이블 아이템 끝 -->
-												<!-- 테이블 아이템 시작 -->
-												<tr class="even">
-													<td class="dtr-control sorting_1 text-right" tabindex="0">000200002</td>
-													<td class="text-right">2025-06-17 20:23:17</td>
-													<td class="text-right">20,000원</td>
-													<td class="text-right">2000p</td>
-													<td class="text-right">신용카드</td>
-													<td class="text-right">testuser1</td>
-													<td class="text-right">
-														<button type="button" class="btn btn-block btn-success btn-sm">배송완료</button>
-													</td>
-													<td class="text-right">
-														<a href="<%=contextPath%>/admin/order/detail"><button type="button" class="btn btn-block btn-primary btn-sm">상세보기</button></a>
-													</td>
-												</tr>
-												<!-- 테이블 아이템 끝 -->
+												<% } %>
 											</tbody>
 											<!-- 테이블 바디 끝 -->
 										</table>
@@ -135,20 +161,37 @@
 								</div>
 								<div class="row justify-content-between">
 									<div class="col-sm-12 col-md-auto">
-										<div class="dataTables_info" id="example2_info" role="status" aria-live="polite">총 57 페이지</div>
+										<div class="dataTables_info" id="example2_info" role="status" aria-live="polite">총 <%= paging.getTotalPage() %> 페이지</div>
 									</div>
 									<div class="col-sm-12 col-md-auto">
 										<div class="dataTables_paginate paging_simple_numbers" id="example2_paginate">
 											<ul class="pagination">
-												<li class="paginate_button page-item previous disabled" id="example2_previous"><a href="#" aria-controls="example2" data-dt-idx="0" tabindex="0" class="page-link">Previous</a></li>
-												<li class="paginate_button page-item active"><a href="#" aria-controls="example2" data-dt-idx="1" tabindex="0" class="page-link">1</a></li>
-												<li class="paginate_button page-item"><a href="#" aria-controls="example2" data-dt-idx="2" tabindex="0" class="page-link">2</a></li>
-												<li class="paginate_button page-item"><a href="#" aria-controls="example2" data-dt-idx="3" tabindex="0" class="page-link">3</a></li>
-												<li class="paginate_button page-item"><a href="#" aria-controls="example2" data-dt-idx="4" tabindex="0" class="page-link">4</a></li>
-												<li class="paginate_button page-item"><a href="#" aria-controls="example2" data-dt-idx="5" tabindex="0" class="page-link">5</a></li>
-												<li class="paginate_button page-item"><a href="#" aria-controls="example2" data-dt-idx="6" tabindex="0" class="page-link">6</a></li>
-												<li class="paginate_button page-item next" id="example2_next"><a href="#" aria-controls="example2" data-dt-idx="7" tabindex="0" class="page-link">Next</a></li>
-											</ul>
+													<%
+													if (paging.getFirstPage() - 1 > 0) {
+													%>
+													<li class="paginate_button page-item previous" id="example2_previous"><a href="<%= contextPath %>/admin/order/history/listpage?pagenum=<%= paging.getCurPos() - 1 %>" aria-controls="example2" data-dt-idx="0" tabindex="0" class="page-link">Previous</a></li>
+													<%
+													} else {
+													%>
+													<li class="paginate_button page-item previous disabled" id="example2_previous"><a href="#" aria-controls="example2" data-dt-idx="0" tabindex="0" class="page-link">Previous</a></li>
+													<% } %>
+													
+													<% for(int i = paging.getFirstPage(); i <= paging.getLastPage(); i++) { 
+														if(i > paging.getTotalPage()) break;
+													%>
+														<li class="paginate_button page-item <% if(i == paging.getCurrentPage()) { out.print("active"); } %>"><a href="<%= contextPath %>/admin/order/history/listpage?pagenum=<%=i%>" aria-controls="example2" data-dt-idx="1" tabindex="0" class="page-link"><%= i %></a></li>
+													<% } %>
+													<%
+													if (paging.getLastPage() < paging.getTotalPage()) {
+													%>
+													<li class="paginate_button page-item next" id="example2_next"><a href="<%= contextPath %>/admin/order/history/listpage?pagenum=<%= paging.getCurPos() + 1 %>" aria-controls="example2" data-dt-idx="7" tabindex="0" class="page-link">Next</a></li>
+													<%
+													} else {
+													%>
+													<li class="paginate_button page-item next disabled" id="example2_next"><a href="#" aria-controls="example2" data-dt-idx="7" tabindex="0" class="page-link">Next</a></li>
+													<% } %>
+													
+												</ul>
 										</div>
 									</div>
 								</div>

--- a/shoppingmall/src/main/webapp/WEB-INF/views/management/order/return.jsp
+++ b/shoppingmall/src/main/webapp/WEB-INF/views/management/order/return.jsp
@@ -1,10 +1,15 @@
+<%@page import="shoppingmall.util.Paging"%>
+<%@page import="shoppingmall.domain.OrderSummary"%>
+<%@page import="java.util.List"%>
 <%@ page contentType="text/html; charset=UTF-8"%>
+<% List<OrderSummary> orderSummaries = (List<OrderSummary>) request.getAttribute("orderSummaries"); %>
+<% Paging paging = (Paging) request.getAttribute("paging"); %>
 <!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>AdminLTE 3 | Dashboard</title>
+<title>SinseBoardGame | 반품내역</title>
 <%@ include file="../inc/head_link.jsp"%>
 </head>
 <body class="hold-transition sidebar-mini layout-fixed">
@@ -23,13 +28,13 @@
 				<div class="container-fluid">
 					<div class="row mb-2">
 						<div class="col-sm-6">
-							<h1 class="m-0">주문내역</h1>
+							<h1 class="m-0">반품내역</h1>
 						</div>
 						<!-- /.col -->
 						<div class="col-sm-6">
 							<ol class="breadcrumb float-sm-right">
 								<li class="breadcrumb-item"><a href="#">Home</a></li>
-								<li class="breadcrumb-item active">주문내역</li>
+								<li class="breadcrumb-item active">반품내역</li>
 							</ol>
 						</div>
 						<!-- /.col -->
@@ -96,38 +101,52 @@
 											<!-- 테이블 헤더 끝 -->
 											<!-- 테이블 바디 시작 -->
 											<tbody>
+												<% for(int i = 0; i < orderSummaries.size(); i++) {
+												OrderSummary orderSummary = orderSummaries.get(i);
+												%>
 												<!-- 테이블 아이템 시작 -->
 												<tr class="odd">
-													<td class="dtr-control sorting_1 text-right" tabindex="0">000200002</td>
-													<td class="text-right">2025-06-17 20:23:17</td>
-													<td class="text-right">20,000원</td>
-													<td class="text-right">2000p</td>
-													<td class="text-right">신용카드</td>
-													<td class="text-right">testuser1</td>
+													<td class="dtr-control sorting_1 text-right" tabindex="0"><%= orderSummary.getOrder_summary_id() %></td>
+													<td class="text-right"><%= orderSummary.getOrdered_at() %></td>
+													<td class="text-right"><%= orderSummary.getTotal_price() %>원</td>
+													<td class="text-right"><%= orderSummary.getPoint_used() %>p</td>
+													<td class="text-right"><%= orderSummary.getPayment_type() %></td>
+													<td class="text-right"><%= orderSummary.getMember().getMember_name() %></td>
 													<td class="text-right">
-														<button type="button" class="btn btn-block btn-danger btn-sm">결제 취소</button>
+														<% 
+															String buttonClassName = "btn-primary";
+															switch(orderSummary.getStatus().getStatus_id()){
+															case 1:
+																buttonClassName = "btn-secondary";
+																break;
+															case 2:
+																buttonClassName = "btn btn-ligh";
+																break;
+															case 3:
+																buttonClassName = "btn-dark";
+																break;
+															case 4:
+																buttonClassName = "btn btn-info";
+																break;
+															case 5:
+																buttonClassName = "btn-success";
+																break;
+															case 6:
+																buttonClassName = "btn-danger";
+																break;
+															default: 
+																buttonClassName = "btn-warning";
+																break;
+															}
+														%>
+														<button type="button" class="btn btn-block <%= buttonClassName %> btn-sm"><%= orderSummary.getStatus().getStatus_name() %></button>
 													</td>
 													<td class="text-right">
-														<button type="button" class="btn btn-block btn-primary btn-sm">상세보기</button>
+														<a href="/admin/order/return/detail?order_summery_id=<%= orderSummary.getOrder_summary_id()%>"><button type="button" class="btn btn-block btn-primary btn-sm">상세보기</button></a>
 													</td>
 												</tr>
 												<!-- 테이블 아이템 끝 -->
-												<!-- 테이블 아이템 시작 -->
-												<tr class="even">
-													<td class="dtr-control sorting_1 text-right" tabindex="0">000200002</td>
-													<td class="text-right">2025-06-17 20:23:17</td>
-													<td class="text-right">20,000원</td>
-													<td class="text-right">2000p</td>
-													<td class="text-right">신용카드</td>
-													<td class="text-right">testuser1</td>
-													<td class="text-right">
-														<button type="button" class="btn btn-block btn-success btn-sm">배송완료</button>
-													</td>
-													<td class="text-right">
-														<a href="<%=contextPath%>/admin/order/detail"><button type="button" class="btn btn-block btn-primary btn-sm">상세보기</button></a>
-													</td>
-												</tr>
-												<!-- 테이블 아이템 끝 -->
+												<% } %>
 											</tbody>
 											<!-- 테이블 바디 끝 -->
 										</table>
@@ -135,20 +154,37 @@
 								</div>
 								<div class="row justify-content-between">
 									<div class="col-sm-12 col-md-auto">
-										<div class="dataTables_info" id="example2_info" role="status" aria-live="polite">총 57 페이지</div>
+										<div class="dataTables_info" id="example2_info" role="status" aria-live="polite">총 <%= paging.getTotalPage() %> 페이지</div>
 									</div>
 									<div class="col-sm-12 col-md-auto">
 										<div class="dataTables_paginate paging_simple_numbers" id="example2_paginate">
 											<ul class="pagination">
-												<li class="paginate_button page-item previous disabled" id="example2_previous"><a href="#" aria-controls="example2" data-dt-idx="0" tabindex="0" class="page-link">Previous</a></li>
-												<li class="paginate_button page-item active"><a href="#" aria-controls="example2" data-dt-idx="1" tabindex="0" class="page-link">1</a></li>
-												<li class="paginate_button page-item"><a href="#" aria-controls="example2" data-dt-idx="2" tabindex="0" class="page-link">2</a></li>
-												<li class="paginate_button page-item"><a href="#" aria-controls="example2" data-dt-idx="3" tabindex="0" class="page-link">3</a></li>
-												<li class="paginate_button page-item"><a href="#" aria-controls="example2" data-dt-idx="4" tabindex="0" class="page-link">4</a></li>
-												<li class="paginate_button page-item"><a href="#" aria-controls="example2" data-dt-idx="5" tabindex="0" class="page-link">5</a></li>
-												<li class="paginate_button page-item"><a href="#" aria-controls="example2" data-dt-idx="6" tabindex="0" class="page-link">6</a></li>
-												<li class="paginate_button page-item next" id="example2_next"><a href="#" aria-controls="example2" data-dt-idx="7" tabindex="0" class="page-link">Next</a></li>
-											</ul>
+													<%
+													if (paging.getFirstPage() - 1 > 0) {
+													%>
+													<li class="paginate_button page-item previous" id="example2_previous"><a href="<%= contextPath %>/admin/order/history/listpage?pagenum=<%= paging.getCurPos() - 1 %>" aria-controls="example2" data-dt-idx="0" tabindex="0" class="page-link">Previous</a></li>
+													<%
+													} else {
+													%>
+													<li class="paginate_button page-item previous disabled" id="example2_previous"><a href="#" aria-controls="example2" data-dt-idx="0" tabindex="0" class="page-link">Previous</a></li>
+													<% } %>
+													
+													<% for(int i = paging.getFirstPage(); i <= paging.getLastPage(); i++) { 
+														if(i > paging.getTotalPage()) break;
+													%>
+														<li class="paginate_button page-item <% if(i == paging.getCurrentPage()) { out.print("active"); } %>"><a href="<%= contextPath %>/admin/order/history/listpage?pagenum=<%=i%>" aria-controls="example2" data-dt-idx="1" tabindex="0" class="page-link"><%= i %></a></li>
+													<% } %>
+													<%
+													if (paging.getLastPage() < paging.getTotalPage()) {
+													%>
+													<li class="paginate_button page-item next" id="example2_next"><a href="<%= contextPath %>/admin/order/history/listpage?pagenum=<%= paging.getCurPos() + 1 %>" aria-controls="example2" data-dt-idx="7" tabindex="0" class="page-link">Next</a></li>
+													<%
+													} else {
+													%>
+													<li class="paginate_button page-item next disabled" id="example2_next"><a href="#" aria-controls="example2" data-dt-idx="7" tabindex="0" class="page-link">Next</a></li>
+													<% } %>
+													
+												</ul>
 										</div>
 									</div>
 								</div>

--- a/shoppingmall/src/main/webapp/WEB-INF/views/management/product/detail.jsp
+++ b/shoppingmall/src/main/webapp/WEB-INF/views/management/product/detail.jsp
@@ -100,6 +100,7 @@ Product product = (Product) request.getAttribute("product");
 			<section class="content">
 				<div class="d-flex flex-row justify-content-end p-4">
 					<a href="<%= contextPath%>/admin/product/modify?product_id=<%= product.getProduct_id()%>"><button id="btn-submit" class="btn btn-primary">수정하기</button></a>
+					<button id="btn-remove" class="btn btn-danger ml-3">삭제하기</button>
 				</div>
 				<div class="row p-4">
 					<div class="card w-100">
@@ -290,6 +291,29 @@ Product product = (Product) request.getAttribute("product");
         setupImageUpload('subImage4', 'subImageInput4');
         setupImageUpload('subImage5', 'subImageInput5');
         
+        $('#btn-remove').click(()=>{
+			if(confirm('상품을 정말 삭제하시겠습니까?')){
+				$.ajax({
+					url: "/admin/product/remove",
+					type: "post",
+					data: {
+						"product_id": "<%= product.getProduct_id()%>"
+					},
+					success: (result, status, xhr) => {
+						if(result.result) {
+						    alert('상품 삭제에 성공하였습니다.');
+						    location.replace('/admin/product/listpage');
+						} else {
+							alert('상품 삭제에 실패하였습니다. error : ' + result.errorMessage);
+						}
+					},
+					error: (xhr, status, error) => {
+						console.log(error);
+					    alert('상품 삭제에 실패하였습니다.');
+					}
+				})
+			}
+        })
         
         $(()=>{
 			$('#theme-select').val('<%=product.getTheme().getTheme_id()%>');


### PR DESCRIPTION
회원정보 상세 페이지
 - 회원 정보 상세 페이지에 주문내역 및 문의내역 볼 수 있도록 하였습니다.

주문관리 페이지
- 주문, 교환, 반품 페이지로 나누어서 내역 확인가능하게 구현 했습니다. (교환 및 반품 데이터는 실제로 넣어서 해보지 못했습니다.)
- 주문 상세에서 주문한 상품의 간단한 정보 및 결제 금액을 볼 수 있습니다. 

상품 삭제 구현
- 상품 삭제 기능은 구현하였으나 다른 테이블에서 상품을 참조하고 있다면 상품이 삭제되지 않습니다.